### PR TITLE
make dev and production configs contingent on env variables

### DIFF
--- a/dlx_rest/config.py
+++ b/dlx_rest/config.py
@@ -13,10 +13,10 @@ class Config(object):
         TESTING = True
     elif 'DLX_REST_DEV' in os.environ:
         client = boto3.client('ssm')
-        connect_string = client.get_parameter(Name='dev-connect-string')['Parameter']['Value']
+        connect_string = client.get_parameter(Name='dlx-dev-connect-string')['Parameter']['Value']
     elif 'DLX_REST_PRODUCTION' in os.environ:
         client = boto3.client('ssm')
-        connect_string = client.get_parameter(Name='production-connect-string')['Parameter']['Value']
+        connect_string = client.get_parameter(Name='dlx-prod-connect-string')['Parameter']['Value']
     else:
         raise Exception('One of the environment variables "DLX_REST_TESTING", "DLX_REST_DEV", or "DLX_REST_PRODUCTION" must return a true value in order to initialize the runtime environment')
 

--- a/dlx_rest/config.py
+++ b/dlx_rest/config.py
@@ -7,19 +7,18 @@ class Config(object):
     DEBUG = False
     TESTING = False
     
-    if 'FLASK_TEST' in os.environ:
+    if 'DLX_REST_TESTING' in os.environ:
         client = None
         connect_string = 'mongomock://localhost'
         TESTING = True
-    else:
+    elif 'DLX_REST_DEV' in os.environ:
         client = boto3.client('ssm')
-        connect_string = client.get_parameter(Name='connect-string')['Parameter']['Value']
+        connect_string = client.get_parameter(Name='dev-connect-string')['Parameter']['Value']
+    elif 'DLX_REST_PRODUCTION' in os.environ:
+        client = boto3.client('ssm')
+        connect_string = client.get_parameter(Name='production-connect-string')['Parameter']['Value']
+    else:
+        raise Exception('One of the environment variables "DLX_REST_TESTING", "DLX_REST_DEV", or "DLX_REST_PRODUCTION" must return a true value in order to initialize the runtime environment')
 
     BIB_COLLECTION = 'bibs'
     AUTH_COLLECTION = 'auths'
-
-class DevelopmentConfig(Config):
-    DEBUG = True
-
-class ProductionConfig(Config):
-    DEBUG = False

--- a/dlx_rest/tests/test_app.py
+++ b/dlx_rest/tests/test_app.py
@@ -1,5 +1,5 @@
 import os
-os.environ['FLASK_TEST'] = 'True'
+os.environ['DLX_REST_TESTING'] = 'True'
 
 import pytest 
 import json, re


### PR DESCRIPTION
As discussed, a suggestion for managing environments. Would require separate credentials for dev and production, and updating the AWS parameter store accordingly, and updating the env variable that's currently set in the Zappa deployment