### PR TITLE
New record landing page

### DIFF
--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -383,4 +383,4 @@ def get_record_by_id(coll,id):
 @login_required
 def create_record(coll):
     this_prefix = url_for('doc', _external=True)
-    return render_template('record.html', prefix=this_prefix)
+    return render_template('record.html', coll=coll, prefix=this_prefix)

--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -382,4 +382,5 @@ def get_record_by_id(coll,id):
 @app.route('/records/<coll>/new')
 @login_required
 def create_record(coll):
-    return render_template('record.html')
+    this_prefix = url_for('doc', _external=True)
+    return render_template('record.html', prefix=this_prefix)

--- a/dlx_rest/static/js/marc.js
+++ b/dlx_rest/static/js/marc.js
@@ -2601,6 +2601,9 @@ class MarcRecord extends HTMLElement {
             if (this.getUrlAPI()) {
                 this.getDataFromApi(this.getUrlAPI());
                 this.getRecordType(this.getUrlAPI());
+            } else {
+                let btn = document.getElementById("btnCreateNewRecord")
+                btn.click()
             }
         }
 

--- a/dlx_rest/static/js/marc.js
+++ b/dlx_rest/static/js/marc.js
@@ -19,6 +19,9 @@ class MarcRecord extends HTMLElement {
         this.id = "marc-record";
         this.recordNumber = "";
         this.recordType = "";
+        if(this.hasAttribute("coll")) {
+            this.recordType = this.getAttribute("coll")
+        }
         this.url = ""
         this.tableNewRecordCreated = false;
         this.displayRecord = false;
@@ -1591,25 +1594,58 @@ class MarcRecord extends HTMLElement {
                     let divRecordType = document.getElementById("divRecordType");
 
                 // create the dropdown list for selecting the type of record    
+                    //this.recordType = this.getRecordType(this.url)
+                    console.log(this.recordType)
+                    let recordTypeSelectElement = document.createElement("select");
+                    recordTypeSelectElement.className = "custom-select";
+                    recordTypeSelectElement.id = "selectTypeRecord";
+                    recordTypeSelectElement.style = "width: 300px;";
+
+                    let bibsOption = document.createElement("option");
+                    bibsOption.value = "bibs";
+                    bibsOption.innerText = "Bibliographic record";
+
+                    let authsOption = document.createElement("option");
+                    authsOption.value = "auths";
+                    authsOption.innerText = "Authority record";
+
+                    if(this.recordType == "bibs") {
+                        bibsOption.selected = true
+                    } else if (this.recordType == "auths") {
+                        authsOption.selected = true
+                    }
+                    
+                    recordTypeSelectElement.appendChild(bibsOption);
+                    recordTypeSelectElement.appendChild(authsOption);
+                    //divContentHeader.appendChild(recordTypeSelectElement);
+
+                    /*
+                    `<select class="custom-select" id="selectTypeRecord" style="width: 300px;">
+                            
+                    <option value="bibs" selected>Bibliographic record</option>
+                    <option value="auths">Authority Record</option>
+            </select>`
+                    */
+
                     if (divRecordType == null) {
                         let myHtml = document.createElement("DIV");
-                        myHtml.innerHTML = `<select class="custom-select" id="selectTypeRecord" style="width: 300px;">
-                                        <!--<option selected>Please select the record type</option>->
-                                        <option value="bibs" selected>Bibliographic record</option>
-                                        <option value="auths">Authority Record</option>
-                                </select>`
+                        myHtml.appendChild(recordTypeSelectElement)
                         myHtml.id = "divRecordType"
                         myHtml.className = "mr-2 mb-2";
                         divContentHeader.appendChild(myHtml);
+                    } else if (divRecordType !== null) {
+                        divRecordType.innerHTML = ''
+                        console.log(recordTypeSelectElement)
+                        divRecordType.appendChild(recordTypeSelectElement)
                     }
 
+                    // How do we make the record type selected based on divRecordType?
+                    /*
                     if (divRecordType !== null) {
-                        divRecordType.innerHTML = `<select class="custom-select" id="selectTypeRecord" style="width: 300px;">
-                            
-                                        <option value="bibs" selected>Bibliographic record</option>
-                                        <option value="auths">Authority Record</option>
-                                </select>`
+                        console.log(recordTypeSelectElement)
+                        divRecordType.innerHTML = recordTypeSelectElement
                     }
+                    */
 
                     const myDiv = document.getElementById("divNewRecord");
                     if (myDiv) {

--- a/dlx_rest/static/js/marc.js
+++ b/dlx_rest/static/js/marc.js
@@ -221,6 +221,11 @@ class MarcRecord extends HTMLElement {
             })
             .then(response => {
                 if (response.ok) {
+                    response.text().then(function(p) {
+                        let record_url = JSON.parse(p)["result"].split('/api')[1];
+                        window.history.pushState("object or string", "Title", "/records" + record_url);
+                    });
+                    
                     divMailHeader.innerHTML = "<div class='alert alert-success mt-2 alert-dismissible fade show' role='alert'>Record created!</div>";
                 }
                 if (!response.ok) {

--- a/dlx_rest/templates/list_records.html
+++ b/dlx_rest/templates/list_records.html
@@ -1,12 +1,12 @@
 {% extends 'base.html' %} {% block content %}
 <nav class="navbar navbar-expand-lg navbar-light bg-light text-center">
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarToggler" aria-controls="navbarToggler" aria-expanded="false" aria-label="Toggle navigation"> <span class="navbar-toggler-icon"> </span></button>
     <form class="form-inline mr-auto col-lg-10" action="{{url_for('search_records', coll=coll)}}">
         {% if q %}
         <input id="q" name="q" class="form-control mr-sm-2 col-lg-10" type="search" aria-label="Search {{coll}} collection" value="{{q}}"> {% else %}
         <input id="q" name="q" class="form-control mr-sm-2 col-lg-10" type="search" placeholder="Search {{coll}} collection" aria-label="Search this collection"> {% endif %}
         <button class="btn btn-primary" type="submit" id="search-btn" value="Search">Search</button>
     </form>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarToggler" aria-controls="navbarToggler" aria-expanded="false" aria-label="Toggle navigation"> <span class="navbar-toggler-icon"> </span></button>
     <div class="collapse navbar-collapse" id="navbarToggler">
         <ul class="navbar-nav">
             {% if current_user.is_authenticated %}

--- a/dlx_rest/templates/list_records.html
+++ b/dlx_rest/templates/list_records.html
@@ -1,43 +1,53 @@
 {% extends 'base.html' %} {% block content %}
-<div class="container">
-    <div class="row">
-        <form class="form-inline" action="{{url_for('search_records', coll=coll)}}">
-            {% if q %}
-            <input id="q" name="q" class="form-control mr-sm-2" type="search" aria-label="Search {{coll}} collection" value="{{q}}"> {% else %}
-            <input id="q" name="q" class="form-control mr-sm-2" type="search" placeholder="Search {{coll}} collection" aria-label="Search this collection"> {% endif %}
-            <button class="btn btn-primary" type="submit" id="search-btn" value="Search">Search</button>
-        </form>
+<nav class="navbar navbar-expand-lg navbar-light bg-light text-center">
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarToggler" aria-controls="navbarToggler" aria-expanded="false" aria-label="Toggle navigation"> <span class="navbar-toggler-icon"> </span></button>
+    <form class="form-inline mr-auto col-lg-10" action="{{url_for('search_records', coll=coll)}}">
+        {% if q %}
+        <input id="q" name="q" class="form-control mr-sm-2 col-lg-10" type="search" aria-label="Search {{coll}} collection" value="{{q}}"> {% else %}
+        <input id="q" name="q" class="form-control mr-sm-2 col-lg-10" type="search" placeholder="Search {{coll}} collection" aria-label="Search this collection"> {% endif %}
+        <button class="btn btn-primary" type="submit" id="search-btn" value="Search">Search</button>
+    </form>
+    <div class="collapse navbar-collapse" id="navbarToggler">
+        <ul class="navbar-nav">
+            {% if current_user.is_authenticated %}
+            <li class="nav-item"><a class="nav-link" href="{{url_for('create_record', coll=coll)}}">Create Record</a></li>
+            {% endif %}
+        </ul>
     </div>
-    <div class="row">
-        <p>
+</nav>
+<nav class="navbar navbar-expand-lg navbar-light bg-white text-center">
+    <div class="collapse navbar-collapse" id="resultsNavbarToggle">
+        <ul class="navbar-nav mr-auto">
             {% set rpp = [10,50,100,500,1000] %}
-            Results:
+            <li class="nav-item"><a class="nav-link disabled">Results per page:</a></li>
             
             {% if limit|int in rpp %}
                 {% for o in rpp %}
                     {% if limit|int == o %}
-                        {{o}}
+                        <a class="nav-link disabled">{{o}}</a>
                     {% else %}
-                        <a href="{{url_for('search_records', coll=coll, q=q, limit=o, sort=sort, direction=direction)}}">{{o}}</a>
+                        <a class="nav-link" href="{{url_for('search_records', coll=coll, q=q, limit=o, sort=sort, direction=direction)}}">{{o}}</a>
                     {% endif %}
                 {% endfor %}
             {% else %}
                 {{limit}}
                 {% for o in rpp %}
-                    <a href="{{url_for('search_records', coll=coll, q=q, limit=o, sort=sort, direction=direction)}}">{{o}}</a>
+                    <a class="nav-link" href="{{url_for('search_records', coll=coll, q=q, limit=o, sort=sort, direction=direction)}}">{{o}}</a>
                 {% endfor %}
             {% endif %}
-            &nbsp;|&nbsp;
-            Sort: updated 
+            <li class="nav-item"><a class="nav-link disabled">&nbsp;|&nbsp;</a></li>
+            <a class="nav-link disabled">Sort: updated </a>
             {% for o in ["asc","desc"] %}
                 {% if direction == o %}
-                    {{o}}
+                    <a class="nav-link disabled">{{o}}</a>
                 {% else %}
-                    <a href="{{url_for('search_records', coll=coll, q=q, limit=limit, sort=sort, direction=o)}}">{{o}}</a>
+                    <a class="nav-link" href="{{url_for('search_records', coll=coll, q=q, limit=limit, sort=sort, direction=o)}}">{{o}}</a>
                 {% endif %}
             {% endfor %}
-        </p>
+        </ul>
     </div>
+</nav>
+<div class="container">
     {% for record in records %}
     <div class="row pt-2 border-bottom">
         <div class="container">

--- a/dlx_rest/templates/record.html
+++ b/dlx_rest/templates/record.html
@@ -4,11 +4,7 @@
     <marc-record url="{{ coll }}/{{ record_id }}" token="{{current_user.is_active}}" prefix="{{prefix}}"></marc-record>
     {% else %}
     <marc-record url="" token="{{current_user.is_active}}" prefix="{{prefix}}"></marc-record>
-    <script type="text/javascript">
-        $(function() {
-            $('#btnCreateNewRecord').click();
-        });
-    </script>
+
     {% endif %}
 </div>
 

--- a/dlx_rest/templates/record.html
+++ b/dlx_rest/templates/record.html
@@ -3,7 +3,7 @@
     {% if record_id %}
     <marc-record url="{{ coll }}/{{ record_id }}" token="{{current_user.is_active}}" prefix="{{prefix}}"></marc-record>
     {% else %}
-    <marc-record url="" token="{{current_user.is_active}}" prefix="{{prefix}}"></marc-record>
+    <marc-record url="" token="{{current_user.is_active}}" prefix="{{prefix}}" coll="{{coll}}"></marc-record>
 
     {% endif %}
 </div>

--- a/dlx_rest/templates/record.html
+++ b/dlx_rest/templates/record.html
@@ -4,6 +4,11 @@
     <marc-record url="{{ coll }}/{{ record_id }}" token="{{current_user.is_active}}" prefix="{{prefix}}"></marc-record>
     {% else %}
     <marc-record url="" token="{{current_user.is_active}}" prefix="{{prefix}}"></marc-record>
+    <script type="text/javascript">
+        $(function() {
+            $('#btnCreateNewRecord').click();
+        });
+    </script>
     {% endif %}
 </div>
 


### PR DESCRIPTION
Navigating to /records/bibs/new and /records/auths/new now brings up the record creation form. 

At the moment, the form actually only opens when the "Create a new record" button is clicked, so I added code in record.html to click that button automatically if there is no record id specified (which if you're creating a new record, there isn't). We can discuss whether this is an appropriate placement for the code or not.

Additionally, clicking the "Save the record" button from a new record interface updates the window.history by pushing a new state. This updates the location without reloading the page.

Not urgent, but to do: 

- Determine where else in the interface we want a "create record" button or link.
- Auto-select the record type based on what collection you came from (right now it defaults to bibs)
- Consider parameterizing the component modes, so we can go directly to an edit form, etc., without the added click in between loading and editing the record. Same with create, so we don't have to have a scripted button click.