### PR TITLE
File enhance

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -865,12 +865,18 @@ class Record(Resource):
         args = post_put_argparser.parse_args()
         
         cls = ClassDispatch.by_collection(collection) or abort(404)
-        record = cls.from_id(record_id) or abort(404)
+
+        if collection == 'files':
+            rid = str(record_id)
+        else:
+            rid = int(record_id)
+
+        record = cls.from_id(rid) or abort(404)
 
         if args.format == 'mrk':
             try:
                 record = cls.from_mrk(request.data.decode())
-                record.id = record_id
+                record.id = rid
                 result = record.commit(user=user)
             except Exception as e:
                 abort(400, str(e))
@@ -895,7 +901,10 @@ class Record(Resource):
         user = 'testing' if current_user.is_anonymous else current_user.email
         
         cls = ClassDispatch.by_collection(collection) or abort(404)
-        record = cls.from_id(record_id) or abort(404)
+        if collection == 'files':
+            record = cls.from_id(str(record_id) or abort(404))
+        else:
+            record = cls.from_id(int(record_id)) or abort(404)
 
         try:
             result = record.delete(user=user)

--- a/dlx_rest/config.py
+++ b/dlx_rest/config.py
@@ -6,6 +6,8 @@ import boto3
 class Config(object):
     DEBUG = False
     TESTING = False
+
+    bucket = 'undl-files'
     
     if 'DLX_REST_TESTING' in os.environ:
         connect_string = 'mongomock://localhost'
@@ -44,3 +46,4 @@ class Config(object):
     JWT_SECRET_KEY = os.environ.get("JWT_SECRET_KEY", os.urandom(24))
     BIB_COLLECTION = 'bibs'
     AUTH_COLLECTION = 'auths'
+    FILE_COLLECTION = 'files'

--- a/dlx_rest/static/js/marc.js
+++ b/dlx_rest/static/js/marc.js
@@ -2307,16 +2307,36 @@ class MarcRecord extends HTMLElement {
             // create the files framework
             if (this.filesAvailable.length > 0) {
                 // adding the logic
+                // console.log(this.filesAvailable)
                 let myHeader = document.createElement("H5");
-                myHeader.innerHTML = "<span class='badge badge-pill badge-success'>" + this.filesAvailable.length + "</span> File(s) available , Click the file path to display the file!!! ";
+                myHeader.innerHTML = "<span class='badge badge-pill badge-success'>" + this.filesAvailable.length + "</span> file(s) available.";
                 let myTable = document.createElement("TABLE");
                 myTable.className = "table table-striped"
                 myTable.innerHTML += "<div>"
-                myTable.innerHTML += "<table><thead> <tr><th>Language</th><th>File path</th></tr></thead><tbody>";
+                myTable.innerHTML += "<table><thead> <tr><th>Language</th><th>Links</th></tr></thead><tbody>";
                 let i;
                 let myTableContent = "";
                 for (i = 0; i < this.filesAvailable.length; i++) {
-                    myTableContent += "<tr><td><span class='text-center ml-2'>" + this.filesAvailable[i]['language'] + "</span></td><td><a href='" + this.filesAvailable[i]['url'] + "' target='_blank'>" + this.filesAvailable[i]['url'] + "</a></td></tr>"
+                    let myTr = document.createElement("TR")
+                    let myTdLangs = document.createElement("TD")
+                    myTdLangs.innerText = this.filesAvailable[i]['language']
+                    let myTdLinks = document.createElement("TD")
+                    let myA_newTab = document.createElement("A")
+                    myA_newTab.href = this.filesAvailable[i]['url']
+                    myA_newTab.target = "_blank"
+                    myA_newTab.innerText = "Open in New Tab"
+                    myTdLinks.appendChild(myA_newTab)
+                    let mySpan = document.createElement("span")
+                    mySpan.classList.add('p-4')
+                    myTdLinks.appendChild(mySpan)
+                    let myA_download = document.createElement("A")
+                    myA_download.href = this.prefixUrl + 'files/' + this.filesAvailable[i]['id'] + "?action=download"
+                    myA_download.innerText = 'Download'
+                    //myA_download.dispatchEvent(new MouseEvent('click'));                
+                    myTdLinks.appendChild(myA_download)
+                    myTr.appendChild(myTdLangs)
+                    myTr.appendChild(myTdLinks)
+                    myTable.appendChild(myTr)
                 }
                 myTable.innerHTML += myTableContent + "</tbody></table></div>"
                 divContent.appendChild(myHeader);

--- a/dlx_rest/tests/test_api.py
+++ b/dlx_rest/tests/test_api.py
@@ -27,7 +27,7 @@ def test_all_routes(client):
 
 def test_collections_list(client, records):
     data = json.loads(client.get(f'{API}/collections').data)
-    assert len(data['results']) == 2
+    assert len(data['results']) == 3
     assert f'{API}/bibs' in data['results']
     assert f'{API}/auths' in data['results']
     


### PR DESCRIPTION
Adds "files" to the list of collections we can query (but only for single records, not for lists of records: i.e., we have Bib, Auth, and File as dlx record types, but only BibSet and AuthSet as record list types; we should expand this to make more options available to the API)

Adds an "action" parameter for GET operations on individual File records. Its only option now is "download", which sends the file to the browser as an attachment. This allows control over the name of the file downloaded.

Removes the unitary S3 URL for file links on Bib records and replaces it with two new links: Open in New Tab and Download. Open in New Tab preserves the original S3 URL and opens the file in a new tab. Download takes advantage of the new File record type and download action to send the file as an attachment, which downloads it with a specified name rather than the S3 key name.

Adds configuration parameters for the S3 bucket and a pointer to the File record type for registry in the collections list.

The tests have been updated to reflect three collections instead of two, and the individual record resource routes have been updated to differentiate between the id styles used for Bib and Auth records (int) and File records (md5 checksum).