### PR TITLE
fix pushstate

### DIFF
--- a/dlx_rest/static/js/marc.js
+++ b/dlx_rest/static/js/marc.js
@@ -225,8 +225,9 @@ class MarcRecord extends HTMLElement {
             .then(response => {
                 if (response.ok) {
                     response.text().then(function(p) {
+                        let record_prefix = JSON.parse(p)["result"].split('/api')[0]
                         let record_url = JSON.parse(p)["result"].split('/api')[1];
-                        window.history.pushState("object or string", "Title", "/records" + record_url);
+                        window.history.pushState("object or string", "Title", record_prefix + "/records" + record_url);
                     });
                     
                     divMailHeader.innerHTML = "<div class='alert alert-success mt-2 alert-dismissible fade show' role='alert'>Record created!</div>";


### PR DESCRIPTION
This fixes an issue where the window.history.pushState command replaces the URL of a newly created record, but has the wrong URL for the Lambda/API Gateway environments.