### PR TITLE
account for trailing slash in api path

### DIFF
--- a/dlx_rest/static/js/jmarc.js
+++ b/dlx_rest/static/js/jmarc.js
@@ -111,7 +111,7 @@ if (nodejs) {
 			lookup() {
 				let collection = this instanceof BibDataField ? "bibs" : "auths";
 				let lookupString = this.subfields.map(x => {return `${x.code}=${x.value}`}).join("&");
-				let url = Jmarc.apiUrl + `/marc/${collection}/lookup/${this.tag}?${lookupString}`;
+				let url = Jmarc.apiUrl + `marc/${collection}/lookup/${this.tag}?${lookupString}`;
 				
 				return fetch(url).then(
 					response => {
@@ -157,8 +157,10 @@ if (nodejs) {
 		class Jmarc {
 			constructor(collection) {
 				Jmarc.apiUrl || function() {throw new Error("Jmarc.apiUrl must be set")};
+				Jmarc.apiUrl = Jmarc.apiUrl.slice(-1) == '/' ? Jmarc.apiUrl : Jmarc.apiUrl + '/'
+				
 				this.collection = collection || function() {throw new Error("Collection required")};
-				this.collectionUrl = Jmarc.apiUrl + `/marc/${collection}`;
+				this.collectionUrl = Jmarc.apiUrl + `marc/${collection}`;
 				this.recordId = null;
 				this.fields = [];
 			}
@@ -175,10 +177,11 @@ if (nodejs) {
 			
 			static get(collection, recordId) {
 				Jmarc.apiUrl || function() {throw new Error("Jmarc.apiUrl must be set")};
+				Jmarc.apiUrl = Jmarc.apiUrl.slice(-1) == '/' ? Jmarc.apiUrl : Jmarc.apiUrl + '/'
 				
 				let jmarc = new Jmarc(collection || function() {throw new Error("Collection required")});
 				jmarc.recordId = parseInt(recordId) || function() {throw new Error("Record ID required")};
-				jmarc.url = Jmarc.apiUrl + `/marc/${collection}/records/${recordId}`;
+				jmarc.url = Jmarc.apiUrl + `marc/${collection}/records/${recordId}`;
 				
 				let savedResponse;
 				

--- a/dlx_rest/tests/jmarc.spec.js
+++ b/dlx_rest/tests/jmarc.spec.js
@@ -1,14 +1,19 @@
+/* The Flask app must be currently running in TESTING mode to use this spec. If
+the app is not in TESTING mode, the spec will fail at the app login prompt. 
+Unset environment variable DLX_REST_DEV and export/setx DLX_REST_TESTING to a
+true value before starting the app */
+
 "use strict";
 
 const jmarcjs = require('../static/js/jmarc.js');
 const Jmarc = jmarcjs.Jmarc;
 const Bib = jmarcjs.Bib;
 const Auth = jmarcjs.Auth;
-//const ControlField = jmarcjs.ControlField;
+const ControlField = jmarcjs.ControlField;
 const DataField = jmarcjs.DataField;
-//const Subfield = jmarcjs.Subfield;
+const Subfield = jmarcjs.Subfield;
 
-Jmarc.apiUrl = "http://localhost:5000/api";
+Jmarc.apiUrl = "http://localhost:5000/api/";
 
 describe(
 	"Jmarc", 


### PR DESCRIPTION
Trailing slash will be expected, but appended to api path if not supplied by user