### PR TITLE
require auth heading field

### DIFF
--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -672,6 +672,12 @@ export class Jmarc {
             }
             
             field.validate()
+            
+            if (this.collection == "auths") {
+                if (! this.fields.map(x => x.tag.substring(0, 1)).includes("1")) {
+                    throw new Error("Heading field required")
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Prevents user from creating or saving auth without heading field