### PR TITLE
Yls feat record created from workform have diff size

### DIFF
--- a/dlx_rest/static/css/record.css
+++ b/dlx_rest/static/css/record.css
@@ -1,12 +1,17 @@
 /* marc record */
 
-table.marc-record {
+/* table.marc-field {
     width: 100%;
 }
 
+table.marc-record {
+    width: 100%;
+} */
+/* 
+
 table.marc-field {
     width: 100%;
-}
+} */
 
 table.marc-record.read-only {
     pointer-events: none;
@@ -70,11 +75,7 @@ td.field-checkbox {
     vertical-align: top
 }
 
-td.field-tag {
-    width: 99px;
-}
-
-td.field-tag {
+/* td.field-tag {
     width: 99px;
 }
 
@@ -84,14 +85,14 @@ td.subfield-code {
 
 td.subfield-value {
     width: 100%; 
-}
+} */
 
 td.unsaved {
     background-color: rgba(255, 255, 128, .5);
 }
 
 span.authority-controlled {
-    text-decoration: underline;;
+    text-decoration: underline;
 }
 
 span.authority-controlled-unmatched {
@@ -109,8 +110,6 @@ span.unsaved {
 span.lookup-choice-code {
     color: blue;
 }
-
-span.lookup-choice-value {}
 
 li.lookup-choice:hover {
     background-color: gray;

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -356,24 +356,6 @@ export let multiplemarcrecordcomponent = {
                 }
             });
             
-            // check the save status on any span
-            // function visualIndicator(){
-            //     alert("inside")
-            //     if (jmarc.saved) {
-            //         jmarc.saveButton.classList.remove("text-danger");
-            //         jmarc.saveButton.classList.add("text-primary");
-            //         jmarc.saveButton.title = "no new changes";
-            //     } else {
-            //         jmarc.saveButton.classList.add("text-danger");
-            //         jmarc.saveButton.classList.remove("text-primary");
-            //         jmarc.saveButton.title = "save";
-            //     }
-            // };
-
-            // var spans = document.getElementsByTagName('span');
-            // for(let i=0;i<spans.length;i++)
-            //     spans[i].onchange=visualIndicator;
-            
             return table       
         },
         buildTableHeader(jmarc) {

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -355,6 +355,22 @@ export let multiplemarcrecordcomponent = {
                     jmarc.saveButton.title = "save";
                 }
             });
+
+            // check the save status on any DIV
+            // table.addEventListener("DOMNodeInserted", function() {
+            //     if (jmarc.saved) {
+            //         jmarc.saveButton.classList.remove("text-danger");
+            //         jmarc.saveButton.classList.add("text-primary");
+            //         jmarc.saveButton.title = "no new changes";
+            //     } else {
+            //         jmarc.saveButton.classList.add("text-danger");
+            //         jmarc.saveButton.classList.remove("text-primary");
+            //         jmarc.saveButton.title = "save";
+            //     }
+            // });
+
+            // check the save status on any SPAN
+
             
             return table       
         },
@@ -829,6 +845,11 @@ export let multiplemarcrecordcomponent = {
             deleteField.addEventListener("click", function() {
                 jmarc.deleteField(field);
                 table.deleteRow(field.row.rowIndex);
+
+                // Change the color of the red button
+                jmarc.saveButton.classList.add("text-danger");
+                jmarc.saveButton.classList.remove("text-primary");
+                jmarc.saveButton.title = "save";
             });
     
             // Tag span

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -355,9 +355,10 @@ export let multiplemarcrecordcomponent = {
                     jmarc.saveButton.title = "save";
                 }
             });
-
-            // check the save status on any DIV
-            // table.addEventListener("DOMNodeInserted", function() {
+            
+            // check the save status on any span
+            // function visualIndicator(){
+            //     alert("inside")
             //     if (jmarc.saved) {
             //         jmarc.saveButton.classList.remove("text-danger");
             //         jmarc.saveButton.classList.add("text-primary");
@@ -367,10 +368,11 @@ export let multiplemarcrecordcomponent = {
             //         jmarc.saveButton.classList.remove("text-primary");
             //         jmarc.saveButton.title = "save";
             //     }
-            // });
+            // };
 
-            // check the save status on any SPAN
-
+            // var spans = document.getElementsByTagName('span');
+            // for(let i=0;i<spans.length;i++)
+            //     spans[i].onchange=visualIndicator;
             
             return table       
         },
@@ -833,6 +835,11 @@ export let multiplemarcrecordcomponent = {
                 document.execCommand("selectall");
                 newField.subfields[0].valueCell.classList.add("unsaved");
 
+                // Manage visual indicators
+                jmarc.saveButton.classList.add("text-danger");
+                jmarc.saveButton.classList.remove("text-primary");
+                jmarc.saveButton.title = "save";
+
                 return
             });
     
@@ -846,10 +853,15 @@ export let multiplemarcrecordcomponent = {
                 jmarc.deleteField(field);
                 table.deleteRow(field.row.rowIndex);
 
-                // Change the color of the red button
-                jmarc.saveButton.classList.add("text-danger");
-                jmarc.saveButton.classList.remove("text-primary");
-                jmarc.saveButton.title = "save";
+                if (jmarc.saved) {
+                    jmarc.saveButton.classList.remove("text-danger");
+                    jmarc.saveButton.classList.add("text-primary");
+                    jmarc.saveButton.title = "no new changes";
+                } else {
+                    jmarc.saveButton.classList.add("text-danger");
+                    jmarc.saveButton.classList.remove("text-primary");
+                    jmarc.saveButton.title = "save";
+                }
             });
     
             // Tag span
@@ -979,6 +991,7 @@ export let multiplemarcrecordcomponent = {
                         } else {
                             field.indicators[1] = span.innerText;
                         }
+
                     });
         
                     span.addEventListener("keydown", function (event) {
@@ -1158,6 +1171,18 @@ export let multiplemarcrecordcomponent = {
                 field.deleteSubfield(subfield);
                 // Remove the subfield row from the table
                 table.deleteRow(subfield.row.rowIndex);
+
+                // Manage visual indicators
+                if (jmarc.saved) {
+                    jmarc.saveButton.classList.remove("text-danger");
+                    jmarc.saveButton.classList.add("text-primary");
+                    jmarc.saveButton.title = "no new changes";
+                } else {
+                    jmarc.saveButton.classList.add("text-danger");
+                    jmarc.saveButton.classList.remove("text-primary");
+                    jmarc.saveButton.title = "save";
+                }
+
             });
     
             // Subfield value

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ mongomock
 pymongo
 pytest
 python-ulid
-troposphere<3
+troposphere


### PR DESCRIPTION
Records created from workforms have different table column widths.
This issue is fixed.
We still have a small gap when we load a workfrom between indicators and the field/value. (The fix is in progress)









































