### PR TITLE
lock major version of vue

### DIFF
--- a/dlx_rest/templates/base.html
+++ b/dlx_rest/templates/base.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.1/css/all.css">
 
     <!-- Vue JS CDN -->
-    <script src="https://unpkg.com/vue"></script>
+    <script src="https://unpkg.com/vue@^2"></script>
     <script src="https://unpkg.com/vuex"></script>
 
     <style>


### PR DESCRIPTION
This doesn't give us a local static copy of Vue 2, but it locks us into the Vue 2 maintenance path. We still need to investigate the means of keeping a static copy of the Vue distribution locally.