### PR TITLE
adjust tag input

### DIFF
--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -943,7 +943,8 @@ export let multiplemarcrecordcomponent = {
         
                 // prevent typing more than 3 characters
                 if (metaKey === false && tagSpan.innerText.length === 3 && event.keyCode > 45 && event.keyCode < 224) {
-                    tagSpan.innerText = ''
+                    //tagSpan.innerText = ''
+                    event.preventDefault()
                 }
             });
     


### PR DESCRIPTION
When tag input field is full, do nothing instead of overwrite the existing text