### PR TITLE
add ps scripts for activate/quickstart/quickshell

### DIFF
--- a/activate.ps1
+++ b/activate.ps1
@@ -1,0 +1,41 @@
+# Deactivate anything that's already active
+Write-Host "Deactivating existing environments"
+if ($env:VIRTUAL_ENV) {
+    Remove-Item env:VIRTUAL_ENV -ErrorAction SilentlyContinue
+}
+if ($function:deactivate) {
+    Remove-Item function:deactivate
+    Remove-Item function:pydoc
+}
+
+# Unset everything
+if (Test-Path DLX_REST_TESTING) {
+    Remove-Item DLX_REST_TESTING
+}
+if (Test-Path DLX_REST_DEV) {
+    Remove-Item DLX_REST_DEV
+}
+if (Test-Path DLX_REST_UAT) {
+    Remove-Item DLX_REST_UAT
+}
+if (Test-Path DLX_REST_QAT) {
+    Remove-Item DLX_REST_QAT
+}
+if (Test-Path DLX_REST_PRODUCTION) {
+    Remove-Item DLX_REST_PRODUCTION
+}
+
+# Figure out if we have environment arguments, and if not, default to DEV
+if ($Args[0]) {
+    $TargetEnv = $args[0] 
+} else {
+    $TargetEnv = "DEV"
+}
+
+# Set the environment variables
+Write-Host "Setting environment to $TargetEnv"
+[environment]::SetEnvironmentVariable("DLX_REST_" + $TargetEnv, "True", "User")
+[environment]::SetEnvironmentVariable("FLASK_APP", "dlx_rest.app", "User")
+
+# Activate the virtual environment
+invoke-expression -Command "$PSScriptRoot\venv\Scripts\activate.ps1"

--- a/activate.sh
+++ b/activate.sh
@@ -17,6 +17,6 @@ unset DLX_REST_
 unset DLX_REST_DEV
 unset DLX_REST_QAT
 unset DLX_REST_UAT
-unset DLX_REST_PROD
+unset DLX_REST_PRODUCTION
 export FLASK_APP="dlx_rest.app"
 export DLX_REST_$ENV="True"

--- a/quickshell.ps1
+++ b/quickshell.ps1
@@ -1,0 +1,44 @@
+# Deactivate anything that's already active
+Write-Host "Deactivating existing environments"
+if ($env:VIRTUAL_ENV) {
+    Remove-Item env:VIRTUAL_ENV -ErrorAction SilentlyContinue
+}
+if ($function:deactivate) {
+    Remove-Item function:deactivate
+    Remove-Item function:pydoc
+}
+
+# Unset everything
+if (Test-Path DLX_REST_TESTING) {
+    Remove-Item DLX_REST_TESTING
+}
+if (Test-Path DLX_REST_DEV) {
+    Remove-Item DLX_REST_DEV
+}
+if (Test-Path DLX_REST_UAT) {
+    Remove-Item DLX_REST_UAT
+}
+if (Test-Path DLX_REST_QAT) {
+    Remove-Item DLX_REST_QAT
+}
+if (Test-Path DLX_REST_PRODUCTION) {
+    Remove-Item DLX_REST_PRODUCTION
+}
+
+# Figure out if we have environment arguments, and if not, default to DEV
+if ($Args[0]) {
+    $TargetEnv = $args[0] 
+} else {
+    $TargetEnv = "DEV"
+}
+
+# Set the environment variables
+Write-Host "Setting environment to $TargetEnv"
+[environment]::SetEnvironmentVariable("DLX_REST_" + $TargetEnv, "True", "User")
+[environment]::SetEnvironmentVariable("FLASK_APP", "dlx_rest.app", "User")
+
+# Activate the virtual environment
+invoke-expression -Command "$PSScriptRoot\venv\Scripts\activate.ps1"
+
+# Now run the application
+invoke-expression -Command "flask shell"

--- a/quickstart.ps1
+++ b/quickstart.ps1
@@ -1,0 +1,44 @@
+# Deactivate anything that's already active
+Write-Host "Deactivating existing environments"
+if ($env:VIRTUAL_ENV) {
+    Remove-Item env:VIRTUAL_ENV -ErrorAction SilentlyContinue
+}
+if ($function:deactivate) {
+    Remove-Item function:deactivate
+    Remove-Item function:pydoc
+}
+
+# Unset everything
+if (Test-Path DLX_REST_TESTING) {
+    Remove-Item DLX_REST_TESTING
+}
+if (Test-Path DLX_REST_DEV) {
+    Remove-Item DLX_REST_DEV
+}
+if (Test-Path DLX_REST_UAT) {
+    Remove-Item DLX_REST_UAT
+}
+if (Test-Path DLX_REST_QAT) {
+    Remove-Item DLX_REST_QAT
+}
+if (Test-Path DLX_REST_PRODUCTION) {
+    Remove-Item DLX_REST_PRODUCTION
+}
+
+# Figure out if we have environment arguments, and if not, default to DEV
+if ($Args[0]) {
+    $TargetEnv = $args[0] 
+} else {
+    $TargetEnv = "DEV"
+}
+
+# Set the environment variables
+Write-Host "Setting environment to $TargetEnv"
+[environment]::SetEnvironmentVariable("DLX_REST_" + $TargetEnv, "True", "User")
+[environment]::SetEnvironmentVariable("FLASK_APP", "dlx_rest.app", "User")
+
+# Activate the virtual environment
+invoke-expression -Command "$PSScriptRoot\venv\Scripts\activate.ps1"
+
+# Now run the application
+invoke-expression -Command "flask run --reload"


### PR DESCRIPTION
Adds some powershell management scripts to work with the application.

Usage:
`<command>.ps1 (TESTING|DEV|QAT|UAT|PRODUCTION)`

activate.ps1 just deactivates and activates the specified environment, defaulting to DEV if it isn't supplied
quickstart.ps1 starts the application with the specified environment, defaulting to DEV if it isn't supplied
quickshell.ps1 runs a flask shell in the specified environment, defaulting to DEV if it isn't supplied