### PR TITLE
Recordview model

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -1480,13 +1480,14 @@ class MyUserProfileRecord(Resource):
         user_id = this_u['id']
         return_data['email'] = this_u.email
         return_data['roles'] = []
+        return_data['default_views'] = []
             
         for r in this_u.roles:
             return_data['roles'].append(r.name or '')
         
         try:
             for v in this_u.default_views:
-                return_data['default_views'].append(v.name)
+                return_data['default_views'].append(v.to_json())
         except KeyError:
             pass
             

--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -1483,6 +1483,12 @@ class MyUserProfileRecord(Resource):
             
         for r in this_u.roles:
             return_data['roles'].append(r.name or '')
+        
+        try:
+            for v in this_u.default_views:
+                return_data['default_views'].append(v.name)
+        except KeyError:
+            pass
             
         my_basket = URL('api_my_basket_record').to_str()
 

--- a/dlx_rest/models.py
+++ b/dlx_rest/models.py
@@ -78,6 +78,19 @@ class RecordView(Document):
     collection = StringField(choices=["bibs","auths"])
     fieldsets = EmbeddedDocumentListField(MarcFieldSet)
 
+    def to_json(self):
+        return_data = {
+            'name': self.name,
+            'collection': self.collection,
+            'fieldsets': []
+        }
+
+        for f in self.fieldsets:
+            return_data['fieldsets'].append({'field': f.field, 'subfields': f.subfields})
+        
+        return return_data
+
+
 
 class User(UserMixin, Document):
     email = StringField(max_length=200, required=True, unique=True)

--- a/dlx_rest/models.py
+++ b/dlx_rest/models.py
@@ -69,10 +69,21 @@ class Basket(Document):
         self.items = []
         self.save()
 
+class MarcFieldSet(EmbeddedDocument):
+    field = StringField(max_length=3, min_length=3, required=True)
+    subfields = ListField()         # Consider adding choices here
+
+class RecordView(Document):
+    name = StringField()
+    collection = StringField(choices=["bibs","auths"])
+    fieldsets = EmbeddedDocumentListField(MarcFieldSet)
+
+
 class User(UserMixin, Document):
     email = StringField(max_length=200, required=True, unique=True)
     password_hash = StringField(max_length=200)
     roles = ListField(ReferenceField(Role))
+    default_views = ListField(ReferenceField(RecordView))
     created = DateTimeField(default=time.strftime('%Y-%m-%d %H:%M:%S',time.localtime(time.time())))
     updated = DateTimeField(default=time.strftime('%Y-%m-%d %H:%M:%S',time.localtime(time.time())))
 


### PR DESCRIPTION
Adds two models, RecordView (a document) and MarcFieldSet (an embedded document).

Extends the User model with a default_views field, of which we should have only one default view per collection (not yet enforced).

Extends /api/user/my_profile to include the default_views data under the data field:

`"default_views": [
            {
                "collection": "bibs",
                "fieldsets": [
                    {
                        "field": "191",
                        "subfields": [
                            "a",
                            "b",
                            "c",
                            "d"
                        ]
                    }
                ],
                "name": "ITP"
            }
        ],`

Using this it should be possible to find the user's default view for a collection and apply it in the UI.

To do: 
* Add the API methods to list Record Views and fetch a Record View by id; 
* Add Flask routes in /admin to list, create, retrieve, update, and delete views (note permissions)
* Add Flask forms and templates for managing record views