### PR TITLE
Roles and Permissions

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -315,10 +315,6 @@ class RecordsList(Resource):
         args = RecordsList.args.parse_args()
     
         user = request_loader(request)
-        print("user and permissions", user.email, user.roles[0].name, user.permissions_list())
-        #if user.email == 'bib_admin@un.org':
-            
-        
 
         if args.format == 'mrk':
             try:
@@ -328,11 +324,6 @@ class RecordsList(Resource):
         else:
             #try:
             jmarc = json.loads(request.data)
-
-            print("jmarc: " + str(jmarc))
-
-            if not has_permission(user, "createRecord", jmarc):
-                abort(403, f'The current user is not authorized to perform this action.')
             
             if '_id' in jmarc:
                 if jmarc['_id'] is None:
@@ -341,6 +332,11 @@ class RecordsList(Resource):
                     abort(400, f'"_id" {jmarc["_id"]} is invalid for a new record')
                 
             record = cls(jmarc, auth_control=True)
+
+            if not has_permission(user, "createRecord", record, collection):
+                abort(403, f'The current user is not authorized to perform this action.')
+
+
             result = record.commit(user=user.email)
             #except Exception as e:
             #    abort(400, str(e))

--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -315,8 +315,9 @@ class RecordsList(Resource):
         args = RecordsList.args.parse_args()
     
         user = request_loader(request)
-        if user.email == 'bib_admin@un.org':
-            print(user.permissions_list())
+        print("user and permissions", user.email, user.roles[0].name, user.permissions_list())
+        #if user.email == 'bib_admin@un.org':
+            
         
 
         if args.format == 'mrk':
@@ -325,24 +326,24 @@ class RecordsList(Resource):
             except Exception as e:
                 abort(400, str(e))
         else:
-            try:
-                jmarc = json.loads(request.data)
+            #try:
+            jmarc = json.loads(request.data)
 
-                print(jmarc)
+            print("jmarc: " + str(jmarc))
 
-                if not has_permission(user, "createRecord", jmarc):
-                    abort(403, f'The current user is not authorized to perform this action.')
+            if not has_permission(user, "createRecord", jmarc):
+                abort(403, f'The current user is not authorized to perform this action.')
+            
+            if '_id' in jmarc:
+                if jmarc['_id'] is None:
+                    del jmarc['_id']
+                else:
+                    abort(400, f'"_id" {jmarc["_id"]} is invalid for a new record')
                 
-                if '_id' in jmarc:
-                    if jmarc['_id'] is None:
-                        del jmarc['_id']
-                    else:
-                        abort(400, f'"_id" {jmarc["_id"]} is invalid for a new record')
-                    
-                record = cls(jmarc, auth_control=True)
-                result = record.commit(user=user.email)
-            except Exception as e:
-                abort(400, str(e))
+            record = cls(jmarc, auth_control=True)
+            result = record.commit(user=user.email)
+            #except Exception as e:
+            #    abort(400, str(e))
         
             if result:
                 data = {'result': URL('api_record', collection=collection, record_id=record.id).to_str()}
@@ -1574,7 +1575,7 @@ class MyBasketRecord(Resource):
                 if override:
                     # Remove it from the other user's basket
                     # Add it to this user's basket
-                    print(lock_status["in"])
+                    #print(lock_status["in"])
                     for losing_basket in Basket.objects(name=lock_status["in"]):
                         #print(losing_basket)
 
@@ -1616,7 +1617,7 @@ class MyBasketItem(Resource):
             item_data = item_data_raw
             if isinstance(item_data_raw, list):
                 item_data = item_data_raw[0]
-            print(item_data)
+            #print(item_data)
             if item_data['collection'] == 'bibs':
                 this_m = Bib.from_id(int(item_data['record_id']))
                 item_data['title'] = this_m.title() or '...'

--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -317,8 +317,7 @@ class RecordsList(Resource):
         user = request_loader(request)
         if user.email == 'bib_admin@un.org':
             print(user.permissions_list())
-        if not has_permission(user, "createRecord"):
-            abort(403, f'The current user is not authorized to perform this action.')
+        
 
         if args.format == 'mrk':
             try:
@@ -330,6 +329,9 @@ class RecordsList(Resource):
                 jmarc = json.loads(request.data)
 
                 print(jmarc)
+
+                if not has_permission(user, "createRecord", jmarc):
+                    abort(403, f'The current user is not authorized to perform this action.')
                 
                 if '_id' in jmarc:
                     if jmarc['_id'] is None:

--- a/dlx_rest/api/utils.py
+++ b/dlx_rest/api/utils.py
@@ -226,3 +226,28 @@ def item_locked(collection, record_id):
             pass
 
     return {"locked": False}
+
+def has_permission(user, action, record):
+    return_bool=False
+    if hasattr(user, 'roles'):
+        for user_role in set(user.roles):
+            for perm in user_role.permissions:
+                if user_role.has_permission(action):
+                    return_bool = True
+                    if record.collection is not None and record.collection == perm.collection:
+                        return_bool = True
+                        if len(perm.constraint_must) > 0:
+                            return_bool = False
+                            for cm in perm.constraint_must:
+                                these_values = record.get_values(cm.field, cm.subfield)
+                                if cm.value in these_values:
+                                    return_bool = True
+                        if len(perm.constraint_must_not) > 0:
+                            return_bool = False
+                            for cm in perm.constraint_must_not:
+                                these_values = record.get_values(cm.field, cm.subfield)
+                                if cm.value in these_values:
+                                    return_bool = False
+                else:
+                    return_bool = False
+    return return_bool

--- a/dlx_rest/api/utils.py
+++ b/dlx_rest/api/utils.py
@@ -251,7 +251,9 @@ def has_permission(user, action, record, collection):
                         pass
             else:
                 bool_list.append("F")
-    print(bool_list)
+    else:
+        bool_list.append("F")
+    print("boolean list:",bool_list)
     if "F" in bool_list:
         return False
     else:

--- a/dlx_rest/api/utils.py
+++ b/dlx_rest/api/utils.py
@@ -228,21 +228,31 @@ def item_locked(collection, record_id):
     return {"locked": False}
 
 def has_permission(user, action, record):
-    return_bool=False
+    bool_list = []
     if hasattr(user, 'roles'):
         for user_role in set(user.roles):
             if user_role.has_permission(action):
                 print("has right action")
-                return_bool = True
+                bool_list.append("T")
                 for perm in user_role.permissions:
                     for cm in perm.constraint_must:
                         if hasattr(cm, "collection"):
                             if cm.collection == record.collection:
-                                return_bool = True
+                                bool_list.append("T")
+                            else:
+                                bool_list.append("F")
                         if hasattr(cm, "field"):
                             these_values = record.get_values(cm.field, cm.subfield)
                             if cm.value in these_values:
-                                return_bool = True
+                                bool_list.append("T")
+                            else:
+                                bool_list.append("F")
                     for cmn in perm.constraint_must_not:
                         pass
-    return return_bool
+            else:
+                bool_list.append("F")
+    print(bool_list)
+    if "F" in bool_list:
+        return False
+    else:
+        return True

--- a/dlx_rest/api/utils.py
+++ b/dlx_rest/api/utils.py
@@ -231,23 +231,18 @@ def has_permission(user, action, record):
     return_bool=False
     if hasattr(user, 'roles'):
         for user_role in set(user.roles):
-            for perm in user_role.permissions:
-                if user_role.has_permission(action):
-                    return_bool = True
-                    if record.collection is not None and record.collection == perm.collection:
-                        return_bool = True
-                        if len(perm.constraint_must) > 0:
-                            return_bool = False
-                            for cm in perm.constraint_must:
-                                these_values = record.get_values(cm.field, cm.subfield)
-                                if cm.value in these_values:
-                                    return_bool = True
-                        if len(perm.constraint_must_not) > 0:
-                            return_bool = False
-                            for cm in perm.constraint_must_not:
-                                these_values = record.get_values(cm.field, cm.subfield)
-                                if cm.value in these_values:
-                                    return_bool = False
-                else:
-                    return_bool = False
+            if user_role.has_permission(action):
+                print("has right action")
+                return_bool = True
+                for perm in user_role.permissions:
+                    for cm in perm.constraint_must:
+                        if hasattr(cm, "collection"):
+                            if cm.collection == record.collection:
+                                return_bool = True
+                        if hasattr(cm, "field"):
+                            these_values = record.get_values(cm.field, cm.subfield)
+                            if cm.value in these_values:
+                                return_bool = True
+                    for cmn in perm.constraint_must_not:
+                        pass
     return return_bool

--- a/dlx_rest/commands.py
+++ b/dlx_rest/commands.py
@@ -1,5 +1,5 @@
 from dlx_rest.app import app
-from dlx_rest.models import User, Role, Permission, Constraint
+from dlx_rest.models import User, Role, Permission
 from bson.objectid import ObjectId
 import click
 import string
@@ -40,6 +40,7 @@ def make_admin(email):
 
 @app.cli.command('init-roles')
 def init_roles():
+    pass
     print("Collecting existing user roles.")
     user_roles = []
     for user in User.objects():
@@ -54,79 +55,5 @@ def init_roles():
     print("Dropping Role and Permission collections.")
     Permission.drop_collection()
     Role.drop_collection()
-    Constraint.drop_collection()
-    '''
-    print("Setting up global admin role.")
-    r = Role(name='admin')
-    for a in ['create','read','update','delete']:
-        for comp in ['Admin', 'User', 'Role', 'Permission', 'File', 'Record']:
-            this_p = Permission(action=f'{a}{comp}')
-            this_p.save()
-    for p in Permission.objects:
-        r.permissions.append(p)
-    r.save()
-    '''
-    # Collection and Location Constraints
-    for coll in ["bibs","auths","files"]:
-        col_c = Constraint(name=f'constraint-{coll}', collection=coll)
-        col_c.save()
-        for c in [{'loc': 'NY', 'code': 'NNUN'}, {'loc': 'GE', 'code': 'SzGeBNU'}]:
-            this_c = Constraint(name=f'constraint-{coll}-{c["loc"]}', collection=coll, field='040', subfield='a', value=c['code'])
-            this_c.save()
 
-    # Global Administrator permissions
-    for a in ['create','read','update','delete']:
-        for comp in ['Admin', 'User', 'Role', 'Permission', 'File', 'Record']:
-            this_p = Permission(action=f'{a}{comp}')
-            this_p.save()
     
-    # Collection and location permissions
-    for a in ['create','read','update','delete']:
-        for comp in ['File', 'Record']:
-            for coll in ["bibs", "auths", "files"]:    
-                col_p = Permission(action=f'{a}{comp}')
-                #col_p.constraint_must.append(Constraint(collection=coll))
-                col_p.constraint_must = list(filter(lambda x: x['collection'] == coll and not x['field'], Constraint.objects))
-                col_p.save()
-                for loc in ['NNUN', 'SzGeBNU']:
-                    if comp == "File" or comp == "Record":
-                        loc_p = Permission(action=f'{a}{comp}')
-                        #loc_p.constraint_must.append(Constraint(collection=coll, field='040', subfield='a', value=loc))
-                        loc_p.constraint_must = list(filter(lambda x: x['collection'] == coll and x['field'] == '040' and x['value'] != loc, Constraint.objects))
-                        loc_p.save()
-
-    r = Role(name='admin')
-    r.permissions = Permission.objects(constraint_must=[], constraint_must_not=[])
-    r.save()
-
-    # Collection admin roles
-    for coll in ["bibs","auths","files"]:
-        admin_r = Role(name=f'{coll}-admin')
-        constraints = Constraint.objects(collection=coll, field=None)
-        permissions = Permission.objects(constraint_must__in=constraints)
-        admin_r.permissions = permissions
-        admin_r.save()
-
-    # Collection location admin roles
-    for coll in ["bibs","auths","files"]:
-        for c in [{'loc': 'NY', 'code': 'NNUN'}, {'loc': 'GE', 'code': 'SzGeBNU'}]:
-            admin_r = Role(name=f'{coll}-{c["loc"]}-admin')
-            constraints = Constraint.objects(collection=coll, field='040', subfield='a', value=c["code"])
-            permissions = Permission.objects(constraint_must__in=constraints)
-            admin_r.permissions = permissions
-            admin_r.save()
-
-    print("Resetting roles for existing users.")
-    for user_role in user_roles:
-        user = User.objects.get(email=user_role['email'])
-        user.roles = []
-        user.save()
-        user.reload()
-        for role in user_role['roles']:
-            user.add_role_by_name(role.name)
-        user.save()
-
-    print('''
-Done. If none of the original users were admin users, you should use the make-admin 
-command to associate at least one user with an admin account.
-    ''')

--- a/dlx_rest/commands.py
+++ b/dlx_rest/commands.py
@@ -63,9 +63,10 @@ def init_roles():
     Role.drop_collection()
     print("Setting up admin role.")
     r = Role(name='admin')
-    for p in ['readAdmin', 'createUser', 'readUser', 'updateUser', 'deleteUser']:
-        this_p = Permission(action=p)
-        this_p.save()
+    for a in ['create','read','update','delete']:
+        for comp in ['Admin', 'User', 'Role', 'Permission', 'File', 'Record']:
+            this_p = Permission(action=f'{a}{comp}')
+            this_p.save()
     for p in Permission.objects:
         r.permissions.append(p)
     r.save()

--- a/dlx_rest/commands.py
+++ b/dlx_rest/commands.py
@@ -56,4 +56,57 @@ def init_roles():
     Permission.drop_collection()
     Role.drop_collection()
 
+    # basic admin permissions
+    admin_permissions = []
+    for action in ["create", "read", "update", "delete"]:
+        for comp in ["Record", "File", "Workform", "Admin", "Role", "Permission", "User"]:
+            this_permission = Permission(action=f'{action}{comp}')
+            this_permission.save()
+            admin_permissions.append(this_permission)
     
+    admin_role = Role(name="admin")
+    admin_role.permissions = admin_permissions
+    admin_role.save()
+
+    # Collection admins
+    for coll in ["bibs", "auths", "files"]:
+        coll_perms = []
+        for action in ["create", "read", "update", "delete"]:
+            this_permission = Permission(action=f'{action}Record', constraint_must=[f'{coll}'])
+            this_permission.save()
+            coll_perms.append(this_permission)
+        # collection role
+        coll_admin = Role(name=f'{coll}-admin')
+        coll_admin.permissions = coll_perms
+        coll_admin.save()
+
+    # Location based collection admins
+    # NY
+    for coll in ["bibs","auths", "files"]:
+        coll_perms = []
+        for action in ["create", "read", "update", "delete"]:
+            ny_permission = Permission(action=f'{action}Record', constraint_must=[f'{coll}|040|a|NNUN'])
+            ny_permission.save()
+            coll_perms.append(ny_permission)
+        # collection role
+        coll_admin = Role(name=f'{coll}-NY-admin')
+        coll_admin.permissions = coll_perms
+        coll_admin.save()
+
+    # GE
+    for coll in ["bibs","auths", "files"]:
+        coll_perms = []
+        for action in ["create", "read", "update", "delete"]:
+            ge_permission = Permission(action=f'{action}Record', constraint_must=[f'{coll}|040|a|SzGeBNU'])
+            ge_permission.save()
+            coll_perms.append(ge_permission)
+        # collection role
+        coll_admin = Role(name=f'{coll}-GE-admin')
+        coll_admin.permissions = coll_perms
+        coll_admin.save()    
+
+    # Resetting previously existing roles
+    for r in user_roles:
+        this_u = User.objects.get(email=r["email"])
+        this_u.roles = r["roles"]
+        this_u.save()

--- a/dlx_rest/config.py
+++ b/dlx_rest/config.py
@@ -15,6 +15,12 @@ class Config(object):
         LOGIN_DISABLED = True
         dbname = 'dlx'
         sync_log_collection = 'sync_log'
+    elif 'DLX_REST_LOCAL' in os.environ:
+        environment = 'dev'
+        connect_string = "mongodb://localhost:27017/?authSource=undlFiles"
+        dbname = 'undlFiles'
+        sync_log_collection = 'sync_log'
+        bucket = 'dev-undl-files'
     elif 'DLX_REST_DEV' in os.environ:
         environment = 'dev'
         client = boto3.client('ssm')

--- a/dlx_rest/models.py
+++ b/dlx_rest/models.py
@@ -158,6 +158,15 @@ class User(UserMixin, Document):
                 return True
         return False
 
+    def permissions_list(self):
+        return_data = []
+        for role in self.roles:
+            for perm in role.permissions:
+                return_data.append(
+                    {'action': perm.action, 'constraints': {'must': perm.constraint_must, 'must_not': perm.constraint_must_not}}
+                )
+        return return_data
+
     @staticmethod
     def verify_auth_token(token):
         s = Serializer(Config.JWT_SECRET_KEY)

--- a/dlx_rest/models.py
+++ b/dlx_rest/models.py
@@ -15,8 +15,15 @@ from dlx_rest.config import Config
 
 ## Setup some models for use
 
+class Constraint(EmbeddedDocument):
+    collection = StringField(required=True)
+    field = StringField()
+    subfield = StringField()
+    value = StringField()
+
 class Permission(Document):
-    action = StringField(primary_key=True)
+    action = StringField(required=True)
+    constraint = EmbeddedDocumentField(Constraint)
 
 class Role(Document):
     name = StringField(primary_key=True)

--- a/dlx_rest/models.py
+++ b/dlx_rest/models.py
@@ -15,17 +15,11 @@ from dlx_rest.config import Config
 
 ## Setup some models for use
 
-class Constraint(Document):
-    name = StringField(required=True, unique=True)
-    collection = StringField()
-    field = StringField()
-    subfield = StringField()
-    value = StringField()
-
 class Permission(Document):
     action = StringField(required=True)
-    constraint_must = ListField(ReferenceField(Constraint))
-    constraint_must_not = ListField(ReferenceField(Constraint))
+    constraint_must = ListField()
+    constraint_must_not = ListField()
+
 
 class Role(Document):
     name = StringField(primary_key=True)

--- a/dlx_rest/models.py
+++ b/dlx_rest/models.py
@@ -23,7 +23,8 @@ class Constraint(EmbeddedDocument):
 
 class Permission(Document):
     action = StringField(required=True)
-    constraint = EmbeddedDocumentField(Constraint)
+    constraint_must = EmbeddedDocumentField(Constraint)
+    constraint_must_not = EmbeddedDocumentField(Constraint)
 
 class Role(Document):
     name = StringField(primary_key=True)

--- a/dlx_rest/models.py
+++ b/dlx_rest/models.py
@@ -15,16 +15,17 @@ from dlx_rest.config import Config
 
 ## Setup some models for use
 
-class Constraint(EmbeddedDocument):
-    collection = StringField(required=True)
+class Constraint(Document):
+    name = StringField(required=True, unique=True)
+    collection = StringField()
     field = StringField()
     subfield = StringField()
     value = StringField()
 
 class Permission(Document):
     action = StringField(required=True)
-    constraint_must = EmbeddedDocumentField(Constraint)
-    constraint_must_not = EmbeddedDocumentField(Constraint)
+    constraint_must = ListField(ReferenceField(Constraint))
+    constraint_must_not = ListField(ReferenceField(Constraint))
 
 class Role(Document):
     name = StringField(primary_key=True)

--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -109,13 +109,13 @@ def logout():
 # Admin section
 @app.route('/admin')
 @login_required
-@requires_permission(register_permission('readAdmin'))
+@requires_permission('readAdmin')
 def admin_index():
     return render_template('admin/index.html', title="Admin")
 
 @app.route('/admin/sync_log')
 @login_required
-@requires_permission(register_permission('readSync'))
+@requires_permission('readSync')
 def get_sync_log():
     items = SyncLog.objects().order_by('-time')
     return render_template('admin/sync_log.html', title="Sync Log", items=items)
@@ -124,14 +124,14 @@ def get_sync_log():
 # Not sure if we should make any of this available to the API
 @app.route('/admin/users')
 @login_required
-@requires_permission(register_permission('readUser'))
+@requires_permission('readUser')
 def list_users():
     users = User.objects
     return render_template('admin/users.html', title="Users", users=users)
 
 @app.route('/admin/users/new', methods=['GET','POST'])
 @login_required
-@requires_permission(register_permission('createUser'))
+@requires_permission('createUser')
 def create_user():
     # To do: add a create user form; separate GET and POST
     form = CreateUserForm()
@@ -165,7 +165,7 @@ def create_user():
 
 @app.route('/admin/users/<id>/edit', methods=['GET','POST'])
 @login_required
-@requires_permission(register_permission('updateUser'))
+@requires_permission('updateUser')
 def update_user(id):
     try:
         user = User.objects.get(id=id)
@@ -206,7 +206,7 @@ def update_user(id):
 
 @app.route('/admin/users/<id>/delete')
 @login_required
-@requires_permission(register_permission('deleteUser'))
+@requires_permission('deleteUser')
 def delete_user(id):
     user = User.objects.get(id=id)
     if user:
@@ -220,14 +220,14 @@ def delete_user(id):
 '''Roles and permissions admin'''
 @app.route('/admin/roles', methods=['GET'])
 @login_required
-@requires_permission(register_permission('readRole'))
+@requires_permission('readRole')
 def get_roles():
     roles = Role.objects
     return render_template('admin/roles.html', title="Roles", roles=roles)
 
 @app.route('/admin/roles/new', methods=['GET', 'POST'])
 @login_required
-@requires_permission(register_permission('createRole'))
+@requires_permission('createRole')
 def create_role():
     form = CreateRoleForm()
     form.permissions.choices = [(p.action, p.action) for p in Permission.objects()]
@@ -258,7 +258,7 @@ def create_role():
 
 @app.route('/admin/roles/<id>', methods=['GET', 'POST'])
 @login_required
-@requires_permission(register_permission('updateRole'))
+@requires_permission('updateRole')
 def update_role(id):
     try:
         role = Role.objects.get(name=id)
@@ -297,7 +297,7 @@ def update_role(id):
 
 @app.route('/admin/roles/<id>/delete')
 @login_required
-@requires_permission(register_permission('deleteRole'))
+@requires_permission('deleteRole')
 def delete_role(id):
     role = Role.objects.get(name=id)
     if role:
@@ -472,7 +472,7 @@ def search_records_old(coll):
 @app.route('/records/<coll>/<id>', methods=['GET'])
 def get_record_by_id(coll,id):
     # register the permission, but don't require it yet, TBI
-    register_permission('updateRecord')
+    #register_permission('updateRecord')
     this_prefix = url_for('doc', _external=True)
     return render_template('record.html', coll=coll, record_id=id, prefix=this_prefix)
 

--- a/dlx_rest/templates/admin/roles.html
+++ b/dlx_rest/templates/admin/roles.html
@@ -5,6 +5,7 @@
         <thead>
             <th>Name</th>
             <th>Permissions</th>
+            <th>Actions</th>
         </thead>
         <tbody>
             {% for role in roles %}
@@ -12,7 +13,40 @@
                 <td>{{role.name}}</td>
                 <td>
                     {% for permission in role.permissions %}
-                        {{permission.action}}{{ ", " if not loop.last else "" }}
+                        {{permission.action}}
+                        {% if permission.constraint_must|length > 0 %}
+                            [
+                            {% for must in permission.constraint_must %}
+                            + {{ must.collection }}
+                                {% if must.field %}
+                                    {{ must.field }}
+                                {% endif %}
+                                {% if must.subfield %}
+                                    ${{must.subfield}}
+                                {% endif %}
+                                {% if must.value %}
+                                    ={{must.value}}
+                                {% endif %}
+                            {% endfor %}
+                            ] 
+                        {% endif %}
+                        {% if permission.constraint_must_not|length > 0 %}
+                            [
+                            {% for must in permission.constraint_must_not %}
+                            - {{ must.collection }}
+                                {% if must.field %}
+                                    {{ must.field }}
+                                {% endif %}
+                                {% if must.subfield %}
+                                    ${{must.subfield}}
+                                {% endif %}
+                                {% if must.value %}
+                                    ={{must.value}}
+                                {% endif %}
+                            {% endfor %}
+                            ] 
+                        {% endif %}
+                        {{ ", " if not loop.last else "" }}
                     {% endfor %}
                 </td>
                 <td>

--- a/dlx_rest/tests/conftest.py
+++ b/dlx_rest/tests/conftest.py
@@ -145,7 +145,7 @@ def roles(permissions):
     from dlx_rest.models import Role
 
     r = Role(name='admin')
-    r.permissions = permissions.objects(constraint_must=[], constraint_must_not=[])
+    r.permissions = Permission.objects(constraint_must=[], constraint_must_not=[])
     r.save()
 
     # Collection admin roles

--- a/dlx_rest/tests/conftest.py
+++ b/dlx_rest/tests/conftest.py
@@ -41,37 +41,37 @@ def default_users():
         'bib-admin': {
             'email': 'bib_admin@un.org',
             'password': 'password',
-            'role': 'bib-admin'
+            'role': 'bibs-admin'
         },
         'auth-admin': {
             'email': 'auth_admin@un.org',
             'password': 'password',
-            'role': 'auth-admin'
+            'role': 'auths-admin'
         },
         'file-admin': {
             'email': 'file_admin@un.org',
             'password': 'password',
-            'role': 'file-admin'
+            'role': 'files-admin'
         },
         'bib-NY-admin': {
             'email': 'bib_ny_admin@un.org',
             'password': 'password',
-            'role': 'bib-NY-admin'
+            'role': 'bibs-NY-admin'
         },
         'auth-NY-admin': {
             'email': 'auth_ny_admin@un.org',
             'password': 'password',
-            'role': 'auth-NY-admin'
+            'role': 'auths-NY-admin'
         },
         'bib-GE-admin': {
             'email': 'bib_ge_admin@un.org',
             'password': 'password',
-            'role': 'bib-GE-admin'
+            'role': 'bibs-GE-admin'
         },
         'auth-GE-admin': {
             'email': 'auth_ge_admin@un.org',
             'password': 'password',
-            'role': 'auth-GE-admin'
+            'role': 'auths-GE-admin'
         },
 
         # Once we have file tests and location data ready, we can enable these users
@@ -171,8 +171,9 @@ def roles(permissions):
 def users(roles, default_users):
     from dlx_rest.models import User
     
-    for utype in ['admin','non-admin']:
+    for utype in default_users:
         u = default_users[utype]
+        print(u)
         user = User(email = u['email'], created=datetime.now())
         user.set_password(u['password'])
         try:

--- a/dlx_rest/tests/conftest.py
+++ b/dlx_rest/tests/conftest.py
@@ -37,7 +37,55 @@ def default_users():
         'new': {
             'email': 'new_test_user@un.org',
             'password': 'password'
-        }
+        },
+        'bib-admin': {
+            'email': 'bib_admin@un.org',
+            'password': 'password',
+            'role': 'bib-admin'
+        },
+        'auth-admin': {
+            'email': 'auth_admin@un.org',
+            'password': 'password',
+            'role': 'auth-admin'
+        },
+        'file-admin': {
+            'email': 'file_admin@un.org',
+            'password': 'password',
+            'role': 'file-admin'
+        },
+        'bib-NY-admin': {
+            'email': 'bib_ny_admin@un.org',
+            'password': 'password',
+            'role': 'bib-NY-admin'
+        },
+        'auth-NY-admin': {
+            'email': 'auth_ny_admin@un.org',
+            'password': 'password',
+            'role': 'auth-NY-admin'
+        },
+        'bib-GE-admin': {
+            'email': 'bib_ge_admin@un.org',
+            'password': 'password',
+            'role': 'bib-GE-admin'
+        },
+        'auth-GE-admin': {
+            'email': 'auth_ge_admin@un.org',
+            'password': 'password',
+            'role': 'auth-GE-admin'
+        },
+
+        # Once we have file tests and location data ready, we can enable these users
+        #'file-NY-admin': {
+        #    'email': 'file_ny_admin@un.org',
+        #    'password': 'password',
+        #    'role': 'file-NY-admin'
+        #},
+        #'file-GE-admin': {
+        #    'email': 'file_ge_admin@un.org',
+        #    'password': 'password',
+        #    'role': 'file-GE-admin'
+        #},
+
     }
 
 

--- a/dlx_rest/tests/conftest.py
+++ b/dlx_rest/tests/conftest.py
@@ -185,6 +185,9 @@ def users(roles, default_users):
 
 @pytest.fixture
 def marc():
+    '''
+    To do: Create default bibs, auths, and templates with location data for location-based permissions testing.
+    '''
     auths = []
     
     for i in range(1, 3):

--- a/dlx_rest/tests/conftest.py
+++ b/dlx_rest/tests/conftest.py
@@ -56,9 +56,12 @@ def db():
 @pytest.fixture(scope='module')
 def permissions():
     from dlx_rest.models import Permission
-    for perm in ['readAdmin','readUser','createUser','updateUser','deleteUser']:
-        p = Permission(action=perm)
-        p.save()
+    for a in ['create','read','update','delete']:
+        for comp in ['Admin', 'User', 'Role', 'Permission', 'File', 'Record']:
+            for coll in ["bibs","auths"]:
+                this_p = Permission(action=f'{a}{comp}')
+                # this_p.constraints = ...
+                this_p.save()
     
     return Permission
 

--- a/dlx_rest/tests/test_api.py
+++ b/dlx_rest/tests/test_api.py
@@ -54,6 +54,28 @@ def test_api_records_list(client, marc):
         
         for i in (1, 2):
             assert f'{API}/marc/{col}/records/{i}' in data['data']
+
+        # POST NY bib record by global administrator == 200
+        # POST NY auth record by global administrator == 200
+        # POST GE bib record by global administrator == 200
+        # POST GE auth record by global administrator == 200
+
+        # POST NY bib record by global bib administrator == 200
+        # POST GE bib record by glbal bib administrator == 200
+        # POST NY auth record by global auth administrator == 200
+        # POST GE auth record by global auth administrator == 200
+
+        # POST NY bib record by global auth administrator == 403
+        # POST GE bib record by glbal auth administrator == 403
+        # POST NY auth record by global bib administrator == 403
+        # POST GE auth record by global bib administrator == 403
+
+        # POST NY bib record by NY bib administrator == 200
+        # POST GE bib record by NY bib administrator == 403
+        # POST NY auth record by NY auth administrator == 200
+        # POST GE auth record by NY auth administrator == 403
+
+        # Other tests to be developed: Roles that can POST and PUT but not DELETE; roles that have permissions with must_not constraints.
             
         # post
         if col == 'bibs':    
@@ -115,7 +137,28 @@ def test_api_record(client, marc):
             res = client.get(f'{API}/marc/{col}/records/{i}')
             data = check_response(res)
             assert data['_meta']['returns'] == f'{API}/schemas/jmarc'
-            
+
+    # PUT NY bib record by global administrator == 200
+    # PUT NY auth record by global administrator == 200
+    # PUT GE bib record by global administrator == 200
+    # PUT GE auth record by global administrator == 200
+
+    # PUT NY bib record by global bib administrator == 200
+    # PUT GE bib record by glbal bib administrator == 200
+    # PUT NY auth record by global auth administrator == 200
+    # PUT GE auth record by global auth administrator == 200
+
+    # PUT NY bib record by global auth administrator == 403
+    # PUT GE bib record by glbal auth administrator == 403
+    # PUT NY auth record by global bib administrator == 403
+    # PUT GE auth record by global bib administrator == 403
+
+    # PUT NY bib record by NY bib administrator == 200
+    # PUT GE bib record by NY bib administrator == 403
+    # PUT NY auth record by NY auth administrator == 200
+    # PUT GE auth record by NY auth administrator == 403
+
+    # Other tests to be developed: Roles that can POST and PUT but not DELETE; roles that have permissions with must_not constraints.          
     # put
     if col == 'bibs':    
         cls = Bib
@@ -132,6 +175,29 @@ def test_api_record(client, marc):
         
     assert res.status_code == 200
     
+    # DELETE NY bib record by global administrator == 200
+    # DELETE NY auth record by global administrator == 200
+    # DELETE GE bib record by global administrator == 200
+    # DELETE GE auth record by global administrator == 200
+
+    # DELETE NY bib record by global bib administrator == 200
+    # DELETE GE bib record by glbal bib administrator == 200
+    # DELETE NY auth record by global auth administrator == 200
+    # DELETE GE auth record by global auth administrator == 200
+
+    # DELETE NY bib record by global auth administrator == 403
+    # DELETE GE bib record by glbal auth administrator == 403
+    # DELETE NY auth record by global bib administrator == 403
+    # DELETE GE auth record by global bib administrator == 403
+
+    # DELETE NY bib record by NY bib administrator == 200
+    # DELETE GE bib record by NY bib administrator == 403
+    # DELETE NY auth record by NY auth administrator == 200
+    # DELETE GE auth record by NY auth administrator == 403
+
+    # Other tests to be developed: Roles that can POST and PUT but not DELETE; roles that have permissions with must_not constraints.      
+
+
     # delete
     res = client.delete(f'{API}/marc/bibs/records/1')
     assert res.status_code == 204

--- a/dlx_rest/tests/test_api.py
+++ b/dlx_rest/tests/test_api.py
@@ -43,8 +43,12 @@ def test_api_collection(client):
         assert data['_meta']['returns'] == f'{API}/schemas/api.null'
         assert data['data'] == {}
         
-def test_api_records_list(client, marc, users, roles, permissions, constraints, default_users):
+def test_api_records_list(client, marc, users, roles, permissions, default_users):
     from dlx.marc import Bib, Auth
+
+    '''
+    Note: This test set is far too large, but it works.
+    '''
 
     # NY Bib Record
     bibNY = Bib()
@@ -67,62 +71,101 @@ def test_api_records_list(client, marc, users, roles, permissions, constraints, 
     authGE.set('100', 'a', 'Heading')
     authGE.set('040', 'a', 'SzGeBNU')
 
+    # Credentials
     # Global administrator
     username = default_users['admin']['email']
     password = default_users['admin']['password']
-    credentials = b64encode(bytes(f"{username}:{password}", "utf-8")).decode("utf-8")
-
-    # POST NY bib record by global administrator == 200
-    res = client.post(f'{API}/marc/bibs/records', data=bibNY.to_json(), headers={"Authorization": f"Basic {credentials}"})
-    assert res.status_code == 201
-
-    # POST NY auth record by global administrator == 200
-    res = client.post(f'{API}/marc/auths/records', data=authNY.to_json(), headers={"Authorization": f"Basic {credentials}"})
-    assert res.status_code == 201
-
-    # POST GE bib record by global administrator == 200
-    res = client.post(f'{API}/marc/bibs/records', data=bibGE.to_json(), headers={"Authorization": f"Basic {credentials}"})
-    assert res.status_code == 201
-
-    # POST GE auth record by global administrator == 200
-    res = client.post(f'{API}/marc/auths/records', data=authGE.to_json(), headers={"Authorization": f"Basic {credentials}"})
-    assert res.status_code == 201
+    admin_credentials = b64encode(bytes(f"{username}:{password}", "utf-8")).decode("utf-8")
 
     # global bib administrator
     username = default_users['bib-admin']['email']
     password = default_users['bib-admin']['password']
-    credentials = b64encode(bytes(f"{username}:{password}", "utf-8")).decode("utf-8")
-
-    # POST NY bib record by global bib administrator == 200
-    res = client.post(f'{API}/marc/bibs/records', data=bibNY.to_json(), headers={"Authorization": f"Basic {credentials}"})
-    assert res.status_code == 201
-
-    # POST GE bib record by glbal bib administrator == 200
-    res = client.post(f'{API}/marc/bibs/records', data=bibGE.to_json(), headers={"Authorization": f"Basic {credentials}"})
-    assert res.status_code == 201
+    bib_admin_credentials = b64encode(bytes(f"{username}:{password}", "utf-8")).decode("utf-8")
 
     # global auth administrator
     username = default_users['auth-admin']['email']
     password = default_users['auth-admin']['password']
-    credentials = b64encode(bytes(f"{username}:{password}", "utf-8")).decode("utf-8")
+    auth_admin_credentials = b64encode(bytes(f"{username}:{password}", "utf-8")).decode("utf-8")
 
+    # NY bib administrator
+    username = default_users['bib-NY-admin']['email']
+    password = default_users['bib-NY-admin']['password']
+    bib_NY_admin_credentials = b64encode(bytes(f"{username}:{password}", "utf-8")).decode("utf-8")
+
+    # NY auth administrator
+    username = default_users['auth-NY-admin']['email']
+    password = default_users['auth-NY-admin']['password']
+    auth_NY_admin_credentials = b64encode(bytes(f"{username}:{password}", "utf-8")).decode("utf-8")
+
+    # POST NY bib record by global administrator == 200
+    res = client.post(f'{API}/marc/bibs/records', data=bibNY.to_json(), headers={"Authorization": f"Basic {admin_credentials}"})
+    assert res.status_code == 201
+
+    # POST NY auth record by global administrator == 200
+    res = client.post(f'{API}/marc/auths/records', data=authNY.to_json(), headers={"Authorization": f"Basic {admin_credentials}"})
+    assert res.status_code == 201
+
+    # POST GE bib record by global administrator == 200
+    res = client.post(f'{API}/marc/bibs/records', data=bibGE.to_json(), headers={"Authorization": f"Basic {admin_credentials}"})
+    assert res.status_code == 201
+
+    # POST GE auth record by global administrator == 200
+    res = client.post(f'{API}/marc/auths/records', data=authGE.to_json(), headers={"Authorization": f"Basic {admin_credentials}"})
+    assert res.status_code == 201
+
+
+    # POST NY bib record by global bib administrator == 200
+    res = client.post(f'{API}/marc/bibs/records', data=bibNY.to_json(), headers={"Authorization": f"Basic {bib_admin_credentials}"})
+    assert res.status_code == 201
+
+    # POST GE bib record by glbal bib administrator == 200
+    res = client.post(f'{API}/marc/bibs/records', data=bibGE.to_json(), headers={"Authorization": f"Basic {bib_admin_credentials}"})
+    assert res.status_code == 201
+    
     # POST NY auth record by global auth administrator == 200
-    res = client.post(f'{API}/marc/auths/records', data=authNY.to_json(), headers={"Authorization": f"Basic {credentials}"})
+    res = client.post(f'{API}/marc/auths/records', data=authNY.to_json(), headers={"Authorization": f"Basic {auth_admin_credentials}"})
     assert res.status_code == 201
 
     # POST GE auth record by global auth administrator == 200
-    res = client.post(f'{API}/marc/auths/records', data=authGE.to_json(), headers={"Authorization": f"Basic {credentials}"})
+    res = client.post(f'{API}/marc/auths/records', data=authGE.to_json(), headers={"Authorization": f"Basic {auth_admin_credentials}"})
     assert res.status_code == 201
 
+    # Here's where we switch collections
+
     # POST NY bib record by global auth administrator == 403
-    # POST GE bib record by glbal auth administrator == 403
+    res = client.post(f'{API}/marc/bibs/records', data=bibNY.to_json(), headers={"Authorization": f"Basic {auth_admin_credentials}"})
+    assert res.status_code == 403
+
+    # POST GE bib record by global auth administrator == 403
+    res = client.post(f'{API}/marc/bibs/records', data=bibGE.to_json(), headers={"Authorization": f"Basic {auth_admin_credentials}"})
+    assert res.status_code == 403
+
     # POST NY auth record by global bib administrator == 403
+    res = client.post(f'{API}/marc/auths/records', data=authNY.to_json(), headers={"Authorization": f"Basic {bib_admin_credentials}"})
+    assert res.status_code == 403
+
     # POST GE auth record by global bib administrator == 403
+    res = client.post(f'{API}/marc/auths/records', data=authGE.to_json(), headers={"Authorization": f"Basic {bib_admin_credentials}"})
+    assert res.status_code == 403
+
+
+    # Now it's down to location based administrators
 
     # POST NY bib record by NY bib administrator == 200
+    res = client.post(f'{API}/marc/bibs/records', data=bibNY.to_json(), headers={"Authorization": f"Basic {bib_NY_admin_credentials}"})
+    assert res.status_code == 201
+
     # POST GE bib record by NY bib administrator == 403
+    res = client.post(f'{API}/marc/bibs/records', data=bibGE.to_json(), headers={"Authorization": f"Basic {bib_NY_admin_credentials}"})
+    assert res.status_code == 403
+
     # POST NY auth record by NY auth administrator == 200
+    res = client.post(f'{API}/marc/auths/records', data=authNY.to_json(), headers={"Authorization": f"Basic {auth_NY_admin_credentials}"})
+    assert res.status_code == 201
+
     # POST GE auth record by NY auth administrator == 403
+    res = client.post(f'{API}/marc/auths/records', data=authGE.to_json(), headers={"Authorization": f"Basic {auth_NY_admin_credentials}"})
+    assert res.status_code == 403
 
     # Other tests to be developed: Roles that can POST and PUT but not DELETE; roles that have permissions with must_not constraints.
         
@@ -156,7 +199,7 @@ def test_api_records_list(client, marc, users, roles, permissions, constraints, 
         res = client.get(f'{API}/marc/{col}/records?search=title:\'AAA\'')
         data = check_response(res)
         assert data['_meta']['returns'] == f'{API}/schemas/api.urllist'
-        assert len(data['data']) == (1 if col == 'bibs' else 0)
+        assert len(data['data']) == (5 if col == 'bibs' else 0)
         
         # sort
         res = client.get(f'{API}/marc/{col}/records?sort=title&direction=asc')

--- a/dlx_rest/tests/test_api.py
+++ b/dlx_rest/tests/test_api.py
@@ -43,7 +43,7 @@ def test_api_collection(client):
         assert data['_meta']['returns'] == f'{API}/schemas/api.null'
         assert data['data'] == {}
         
-def test_api_records_list(client, marc, users, roles, default_users):
+def test_api_records_list(client, marc, users, roles, permissions, constraints, default_users):
     from dlx.marc import Bib, Auth
 
     # NY Bib Record

--- a/dlx_rest/tests/test_app.py
+++ b/dlx_rest/tests/test_app.py
@@ -40,6 +40,7 @@ def test_login(client, default_users):
     user = default_users['invalid']
     rv = login(client, user['email'], user['password'])
     assert rv.status_code == 200
+    print(rv.data)
     assert b'Invalid username or password' in rv.data
 
 def test_logout(client):

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,4 @@
+export FLASK_APP="dlx_rest.app"
+export DLX_REST_TESTING="True"
+
+pytest -x


### PR DESCRIPTION
This PR addresses #388 and includes the following:

* Updated roles and permissions models to include actions and constraints (must and must not). Constraints are in the form `<collection>|<field>|<subfield>|<value>` and are optional but used for constrained roles.
* Updated user model to list permissions.
* Revamped api.utils.has_permissions() function to iterate through permission actions and constraints to determine if the user has permission to perform the action.
* Add testing-level authentication to the routes that need them.
* Create tests for all createRecord actions across the global, collection, and location-based admin roles.
* Updated management command to initialize or re-initialize roles and permissions: `flask init-roles`

Still to do (coming in this PR):

* Expand tests to updateRecord and deleteRecord actions across the global, collection, and location-based admin roles.
* Expose 403 not authorized messaging to the record editor