### PR TITLE
Auth review 2

### DIFF
--- a/dlx_rest/commands.py
+++ b/dlx_rest/commands.py
@@ -56,9 +56,10 @@ def init_roles():
     Permission.drop_collection()
     Role.drop_collection()
 
-    auth_review = Permission(action="reviewAuths", constraint_must=['auths'])
+    # These are only for use by the admin, which has no constraints
+    auth_review = Permission(action="reviewAuths")
     auth_review.save()
-    merge_auth = Permission(action="mergeAuthority", constraint_must=["auths"])
+    merge_auth = Permission(action="mergeAuthority")
     merge_auth.save()
 
     # basic admin permissions
@@ -83,6 +84,11 @@ def init_roles():
             this_permission.save()
             coll_perms.append(this_permission)
         if coll == "auths":
+            # These are the correct, constrained permissions for auth admins
+            auth_review = Permission(action="reviewAuths", constraint_must=['auths'])
+            auth_review.save()
+            merge_auth = Permission(action="mergeAuthority", constraint_must=["auths"])
+            merge_auth.save()
             coll_perms.append(auth_review)
             coll_perms.append(merge_auth)
         # collection role

--- a/dlx_rest/commands.py
+++ b/dlx_rest/commands.py
@@ -56,6 +56,11 @@ def init_roles():
     Permission.drop_collection()
     Role.drop_collection()
 
+    auth_review = Permission(action="reviewAuths", constraint_must=['auths'])
+    auth_review.save()
+    merge_auth = Permission(action="mergeAuthority", constraint_must=["auths"])
+    merge_auth.save()
+
     # basic admin permissions
     admin_permissions = []
     for action in ["create", "read", "update", "delete"]:
@@ -64,6 +69,8 @@ def init_roles():
             this_permission.save()
             admin_permissions.append(this_permission)
     
+    admin_permissions.append(auth_review)
+    admin_permissions.append(merge_auth)
     admin_role = Role(name="admin")
     admin_role.permissions = admin_permissions
     admin_role.save()
@@ -75,6 +82,9 @@ def init_roles():
             this_permission = Permission(action=f'{action}Record', constraint_must=[f'{coll}'])
             this_permission.save()
             coll_perms.append(this_permission)
+        if coll == "auths":
+            coll_perms.append(auth_review)
+            coll_perms.append(merge_auth)
         # collection role
         coll_admin = Role(name=f'{coll}-admin')
         coll_admin.permissions = coll_perms

--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -455,7 +455,7 @@ def review_auth():
     api_prefix = url_for('doc', _external=True)
     limit = request.args.get('limit', 25)
     start = request.args.get('start', 1)
-    q = request.args.get('q', f'updated>{min_date} AND NOT 999__c:t')
+    q = request.args.get('q', f'updated>{min_date} AND NOT 999__c:\'t\'')
     sort =  request.args.get('sort')
     direction = request.args.get('direction') #, 'desc' if sort == 'updated' else '')
                 

--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -1,4 +1,5 @@
 # Imports from requirements.txt
+from cmath import sin
 from email.policy import default
 import re
 import dlx
@@ -451,21 +452,26 @@ def facet_record(coll):
 @requires_permission("reviewAuths")
 def review_auth():
     api_prefix = url_for('doc', _external=True)
+
+    # Set this minimim date to prevent all authorities from showing up in the list
+    min_date = "2022-04-01"
+
     limit = request.args.get('limit', 25)
     start = request.args.get('start', 1)
     q = request.args.get('q', '')
-    sort =  request.args.get('sort')
-    direction = request.args.get('direction') #, 'desc' if sort == 'updated' else '')
-                
-    if not sort:
-        sort = 'updated'
-        direction = 'desc'
-    elif sort != 'relevance' and not direction:
-        direction = 'asc'
+    since_date = request.args.get('since', min_date)
+    auth_type = request.args.get('type')
+    #sort =  request.args.get('sort')
+    #direction = request.args.get('direction') #, 'desc' if sort == 'updated' else '')
 
-    search_url = url_for('api_records_list', collection="auths", start=start, limit=limit, sort=sort, direction=direction, search=q, _external=True, format='brief')
+    if auth_type:
+        q += f'AND updated>{since_date} AND {auth_type}:* AND NOT 999__c:t'
+    else:
+        q += f'AND updated>{since_date} AND NOT 999__c:t'
 
-    return render_template('review_auths.html', api_prefix=api_prefix, search_url=search_url)
+    search_url = url_for('api_records_list', collection="auths", start=start, limit=limit, search=q, _external=True, format='brief')
+
+    return render_template('review_auths.html', api_prefix=api_prefix, search_url=search_url, collection="auths", since=since_date)
 
 
 def search_records_old(coll):

--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -446,7 +446,11 @@ def browse_list(coll, index):
 def facet_record(coll):
     return {"Facets..."}
 
-
+@app.route('/records/auths/review')
+@login_required
+@requires_permission("reviewAuths")
+def review_auth():
+    return {"Review auths"}
 
 
 def search_records_old(coll):

--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -455,7 +455,7 @@ def review_auth():
     api_prefix = url_for('doc', _external=True)
     limit = request.args.get('limit', 25)
     start = request.args.get('start', 1)
-    q = request.args.get('q', f'updated>{min_date} AND AND NOT 999__c:t')
+    q = request.args.get('q', f'updated>{min_date} AND NOT 999__c:t')
     sort =  request.args.get('sort')
     direction = request.args.get('direction') #, 'desc' if sort == 'updated' else '')
                 

--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -450,7 +450,22 @@ def facet_record(coll):
 @login_required
 @requires_permission("reviewAuths")
 def review_auth():
-    return {"Review auths"}
+    api_prefix = url_for('doc', _external=True)
+    limit = request.args.get('limit', 25)
+    start = request.args.get('start', 1)
+    q = request.args.get('q', '')
+    sort =  request.args.get('sort')
+    direction = request.args.get('direction') #, 'desc' if sort == 'updated' else '')
+                
+    if not sort:
+        sort = 'updated'
+        direction = 'desc'
+    elif sort != 'relevance' and not direction:
+        direction = 'asc'
+
+    search_url = url_for('api_records_list', collection="auths", start=start, limit=limit, sort=sort, direction=direction, search=q, _external=True, format='brief')
+
+    return render_template('review_auths.html', api_prefix=api_prefix, search_url=search_url)
 
 
 def search_records_old(coll):

--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -451,27 +451,23 @@ def facet_record(coll):
 @login_required
 @requires_permission("reviewAuths")
 def review_auth():
+    min_date = "2022-03-01"
     api_prefix = url_for('doc', _external=True)
-
-    # Set this minimim date to prevent all authorities from showing up in the list
-    min_date = "2022-04-01"
-
     limit = request.args.get('limit', 25)
     start = request.args.get('start', 1)
-    q = request.args.get('q', '')
-    since_date = request.args.get('since', min_date)
-    auth_type = request.args.get('type')
-    #sort =  request.args.get('sort')
-    #direction = request.args.get('direction') #, 'desc' if sort == 'updated' else '')
+    q = request.args.get('q', f'updated>{min_date} AND AND NOT 999__c:t')
+    sort =  request.args.get('sort')
+    direction = request.args.get('direction') #, 'desc' if sort == 'updated' else '')
+                
+    if not sort:
+        sort = 'updated'
+        direction = 'desc'
+    elif sort != 'relevance' and not direction:
+        direction = 'asc'
 
-    if auth_type:
-        q += f'AND updated>{since_date} AND {auth_type}:* AND NOT 999__c:t'
-    else:
-        q += f'AND updated>{since_date} AND NOT 999__c:t'
+    search_url = url_for('api_records_list', collection="auths", start=start, limit=limit, sort=sort, direction=direction, search=q, _external=True, format='brief')
 
-    search_url = url_for('api_records_list', collection="auths", start=start, limit=limit, search=q, _external=True, format='brief')
-
-    return render_template('review_auths.html', api_prefix=api_prefix, search_url=search_url, collection="auths", since=since_date)
+    return render_template('review_auths.html', api_prefix=api_prefix, search_url=search_url, collection="auths")
 
 
 def search_records_old(coll):

--- a/dlx_rest/static/js/auth_review.js
+++ b/dlx_rest/static/js/auth_review.js
@@ -1,0 +1,562 @@
+import { sortcomponent } from "./search/sort.js";
+import { countcomponent } from "./search/count.js";
+import basket from "./api/basket.js";
+import user from "./api/user.js";
+
+export let authreviewcomponent = {
+    props: {
+        api_prefix: {
+            type: String,
+            required: true
+        },
+        search_url: {
+            type: String,
+            required: true
+        },
+        logged_in: {
+            type: String,
+            required: true
+        }
+    },
+    template: ` 
+    <div class="col-sm-8 pt-2" id="app1" style="background-color:white;">
+        <h1>Authorities Review</h1>
+        <nav>
+            <ul class="pagination pagination-md justify-content-center">
+                <li class="page-item disabled">
+                    <span class="page-link">
+                        {{start}} to {{end}} of
+                        <span id="result-count-top">
+                            <div class="spinner-grow" role="status" style="width:1rem;height:1rem">
+                                <span class="sr-only">Loading...</span>
+                            </div>
+                        </span>
+                        Records ({{searchTime}} seconds)
+                    </span>
+                </li>
+                <li v-if="prev" class="page-item"><a class="page-link" :href="prev">Previous</a></li>
+                <li v-else class="page-item disabled"><a class="page-link" href="">Previous</a></li>
+                <li v-if="next" class="page-item"><a class="page-link" :href="next">Next</a></li>
+                <li v-else class="page-item disabled"><a class="page-link" href="">Next</a></li>
+            </ul>
+        </nav>
+        <div id="results-spinner" class="col d-flex justify-content-center">
+            <div class="spinner-border" role="status">
+                <span class="sr-only">Loading...</span>
+            </div>
+        </div>
+        <br>
+        <div id="message-display" class="col-xs-1 text-center"></div>
+        <div id="results-list" v-for="result in this.results" :key="result._id">
+            <div class="row pt-2 border-bottom">
+                <div class="col-sm-11 px-4 shadow bg-light rounded">
+                    <div class="row">
+                        <a v-if="allowDirectEdit" :id="'link-' + result._id" class="lead" :href="uibase + '/editor?records=' + collection + '/' + result._id">{{result.first_line}}</a>
+                        <a v-else class="lead" :id="'link-' + result._id" :href="uibase + '/records/' + collection + '/' + result._id">{{result.first_line}}</a>
+                        <countcomponent v-if="collection == 'auths'" :api_prefix="api_prefix" :recordId="result._id"></countcomponent>
+                    </div>
+                    <div class="row">
+                        <p>{{result.second_line}}</p>
+                    </div>
+                </div>
+                <div class="col-sm-1">
+                    <!-- need to test if authenticated here -->
+                    <div class="row ml-auto">
+                        <a><i :id="'icon-' + collection + '-' + result._id" class="fas fa-2x" data-toggle="tooltip" title="Add to your basket"></i></a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        </br>
+        <nav>
+            <ul class="pagination pagination-md justify-content-center">
+                <li class="page-item disabled">
+                    <span class="page-link">
+                        {{start}} to {{end}} of 
+                        <span id="result-count-bottom">
+                            <div class="spinner-grow" role="status" style="width:1rem;height:1rem">
+                                <span class="sr-only">Loading...</span>
+                            </div>
+                        </span>
+                        Records ({{searchTime}} seconds)
+                    </span>
+                </li>
+                <li v-if="prev" class="page-item"><a class="page-link" :href="prev">Previous</a></li>
+                <li v-else class="page-item disabled"><a class="page-link" href="">Previous</a></li>
+                <li v-if="next" class="page-item"><a class="page-link" :href="next">Next</a></li>
+                <li v-else class="page-item disabled"><a class="page-link" href="">Next</a></li>
+            </ul>
+        </nav>
+    </div>`,
+    data: function () {
+        let myParams = this.search_url.split("?")[1];
+        let myProps = {}
+        for (let p of myParams.split("&")) {
+            let thisParam = p.split("=");
+            if (thisParam[0] == "start" || thisParam[0] == "limit") {
+                myProps[thisParam[0]] = parseInt(thisParam[1]);
+            } else {
+                myProps[thisParam[0]] = decodeURIComponent(thisParam[1]).replace(/\+/g, ' ');
+            }
+        }
+        let myUIBase = this.api_prefix.replace('/api/','');
+        //console.log(this.links)
+        return {
+            visible: true,
+            results: [],
+            links: {},
+            action: `${myUIBase}/records/${this.collection}/search`,
+            params: myProps,
+            searchType: "all",
+            advancedParams: {
+                'searchType1': 'all',
+                'searchTerm1': null,
+                'searchField1': 'any',
+                'searchConnector1': 'AND',
+                'searchType2': 'all',
+                'searchTerm2': null,
+                'searchField2': 'any',
+                'searchConnector2': 'AND',
+                'searchType3': 'all',
+                'searchTerm3': null,
+                'searchField3': 'any'
+            },
+            // To do: Get these logical fields from the configuration
+            bibSearchFields: ['author','title','symbol','notes','subject'],
+            authSearchFields: ['heading', 'agenda_title', 'agenda_subject'],
+            voteSearchFields: ['symbol','title','agenda','year'],
+            speechSearchFields: ['symbol'],
+            searchFields: [],
+            searchTypes: [
+                {'name': 'All of the words:', 'value': 'all'},
+                {'name': 'Any of the words:', 'value': 'any'},
+                {'name': 'Exact prhase:', 'value': 'exact'},
+                {'name': 'Partial prhase:', 'value': 'partial'},
+                {'name': 'Regular expression:', 'value': 'regex'},
+            ],
+            uibase: myUIBase,
+            count: null,
+            prev: null,
+            next: null,
+            resultcount: 0,
+            start: 0,
+            end: 0,
+            basketcontents: ['foo'],
+            lookup_maps: {},
+            expressions: [],
+            vcoll: null,
+            searchTime: 0,
+            maxTime: 15000, //milliseconds
+            abortController: new AbortController()
+        }
+    },
+    created: async function() {
+        this.allowDirectEdit = this.logged_in ? true : false;
+    },
+    mounted: async function() {
+        let component = this;
+        
+        // [what is this used for?]
+        if (component.collection == "auths") {
+            this.searchFields = this.authSearchFields
+            let authLookupMapUrl = `${component.api_prefix}marc/${component.collection}/lookup/map`
+            let authMapResponse = await fetch(authLookupMapUrl);
+            let authMapData = await authMapResponse.json();
+            component.lookup_maps['auths'] = authMapData.data;
+        
+            let bibLookupMapUrl = `${component.api_prefix}marc/bibs/lookup/map`
+            let bibMapResponse = await fetch(bibLookupMapUrl);
+            let bibMapData = await bibMapResponse.json();
+            component.lookup_maps['bibs'] = bibMapData.data;
+        } else if (component.collection == "bibs") {
+            this.searchFields = this.bibSearchFields
+        } 
+        if (this.params.search.includes("989:Voting Data")) {
+            this.searchFields = this.voteSearchFields
+            this.vcoll = "989:Voting Data"
+        } 
+        if (this.params.search.includes("989:Speeches")) {
+            this.searchFields = this.speechSearchFields
+            this.vcoll = "989:Speeches"
+        }
+
+        let myEnd = component.params.start + component.params.limit -1;
+        component.end = myEnd;
+        component.start = component.params.start;
+        let startTime = Date.now();
+
+        // start the count
+        fetch(this.search_url.replace('/records', '/records/count'), this.abortController).then(
+            response => response.json()
+        ).then(
+            jsonData => {
+                component.resultcount = jsonData["data"];
+                
+                // override the spinner
+                document.getElementById("result-count-top").innerHTML = component.resultcount;
+                document.getElementById("result-count-bottom").innerHTML = component.resultcount;
+
+                if (component.resultcount == 0) {
+                    component.start = 0;
+                }
+                
+                if (myEnd >= component.resultcount) {
+                    component.end = component.resultcount
+                    component.next = null
+                }
+            }
+        ).catch(
+            error => {
+                if (error.name === "AbortError") {
+                    document.getElementById("result-count-top").innerHTML = '⏱'
+                    document.getElementById("result-count-bottom").innerHTML = '⏱'
+                }
+            }
+        );
+        
+        fetch(this.search_url, this.abortController).then(
+            response => {
+                if (response.ok) {
+                    document.getElementById("results-spinner").remove();
+                    return response.json();
+                }
+            }
+        ).then(
+            jsonData => {
+                if (! jsonData) {
+                    throw new Error("Invalid search")
+                }
+
+                component.searchTime = (Date.now() - startTime) / 1000;
+
+                let linkKeys = Object.keys(jsonData["_links"]);
+                linkKeys.forEach((key, index) => {
+                    component.links[key] = jsonData["_links"][key];
+                });
+                if (component.links.related.count) {
+                    component.count = component.links.related.count;
+                }
+                if (component.links._prev) {
+                    component.prev = component.links._prev.replace('&search','&q').replace('/records','/search').replace('/api/marc','/records');
+                }
+                if (component.links._next) {
+                    component.next = component.links._next.replace('&search','&q').replace('/records','/search').replace('/api/marc','/records');
+                }
+                for (let result of jsonData["data"]) {
+                    let myResult = { "_id": result["_id"]}
+                    if (component.collection == "bibs") {
+                        myResult["first_line"] = result["title"]
+                        myResult["second_line"] = [result["symbol"], result["date"], result["types"]].filter(Boolean).join(" | ")
+                    } else if (component.collection == "auths") {
+                        myResult["first_line"] = result["heading"]
+                        myResult["second_line"] = result["alt"]
+                        myResult["heading_tag"] = result["heading_tag"];
+                    } else if (component.collection == "files") {
+                        // not implemented yet
+                    }
+                    component.results.push(myResult);
+                }
+            }
+        ).catch(
+            error => {
+                if ((Date.now() - startTime) >= this.maxTime) {
+                    this.reportError(`The search is taking longer than the maximum time allowed (${this.maxTime / 1000} seconds). Try narrowing the search.`)
+                } else if (error.name === "AbortError") {
+                    this.reportError("Search cancelled")
+                } else {
+                    this.reportError(error.toString())
+                }
+            }
+
+        ).then( 
+            () => {
+                user.getProfile(component.api_prefix, 'my_profile').then(
+                    myProfile => {
+                        //console.log("got my profile")
+                        if (myProfile) {
+                            component.user = myProfile.data.email;
+                        }
+                    
+                        if (typeof component.user !== "undefined") {
+                            //console.log("this user is not undefined")
+                            basket.getBasket(component.api_prefix).then(
+                                myBasket => {
+                                    //console.log(myBasket)
+                                    //console.log("got my basket contents")
+                                    for (let result of component.results) {
+                                        //console.log("processing result")
+                                        let myId = `icon-${component.collection}-${result._id}`;
+                                        let iconEl = document.getElementById(myId);
+                                    
+                                        if (component.basketContains(myBasket, component.collection, result._id)) {
+                                            //iconEl.classList.remove('fa-folder-plus',);
+                                            iconEl.classList.add("fa-folder-minus");
+                                            iconEl.classList.add("text-muted");
+                                            iconEl.title = "Remove from basket";
+                                        } else {
+                                            iconEl.classList.add('fa-folder-plus');
+                                            iconEl.title = "Add to basket";
+                                        }
+
+                                        // checking if the record is locked and displaying a lock if it is.
+                                        basket.itemLocked(this.api_prefix, this.collection, result._id).then(
+                                            itemLocked => {
+                                                if (itemLocked["locked"] == true && itemLocked["by"] != this.user) {
+                                                    // Display a lock icon
+                                                    iconEl.classList.remove('fa-folder-plus',);
+                                                    iconEl.classList.remove('fa-folder-minus',);
+                                                    iconEl.classList.add('fa-lock',);
+                                                    iconEl.title = `This item is locked by ${itemLocked["by"]}`;
+                                                    // revert link to read only view. 
+                                                    // TODO: acquire the lock status earlier 
+                                                    document.getElementById("link-" + result._id).href = this.uibase + '/records/' + this.collection + '/' + result._id;
+                                                }
+                                            }
+                                        );
+
+                                        iconEl.addEventListener("click", function() {
+                                            if (iconEl.classList.contains("fa-folder-plus")) {
+                                                //console.log("We're trying to create something.")
+                                                basket.getBasket(component.api_prefix)
+                                                iconEl.classList.add("fa-spinner");
+                                                // we can run an add
+                                                basket.createItem(component.api_prefix, 'userprofile/my_profile/basket', component.collection, result._id).then(
+                                                    function() {
+                                                        iconEl.classList.remove("fa-spinner");
+                                                        iconEl.classList.remove("fa-folder-plus");
+                                                        iconEl.classList.add("fa-folder-minus");
+                                                        iconEl.classList.add("text-muted");
+                                                        iconEl.title = "Remove from basket";
+                                                    }
+                                                )
+                                            } else if (iconEl.classList.contains("fa-folder-minus")) {
+                                                //console.log("We're trying to delete something.")
+                                                basket.getBasket(component.api_prefix)
+                                                iconEl.classList.add("fa-spinner");
+                                                // we can run a deletion
+                                                basket.deleteItem(component.api_prefix, 'userprofile/my_profile/basket', myBasket, component.collection, result._id).then(
+                                                    function() {
+                                                        //console.log("But did we do it?")
+                                                        iconEl.classList.remove("fa-spinner");
+                                                        iconEl.classList.remove("fa-folder-minus");
+                                                        iconEl.classList.add("fa-folder-plus");
+                                                        iconEl.classList.remove("text-muted");
+                                                        iconEl.title = "Add to basket";
+                                                    }
+                                                )
+                                            } else if (iconEl.classList.contains("fa-lock")) {
+                                                // TODO: unlock
+
+                                            }
+                                        });
+                                    }
+                                }
+                            )
+                        }        
+                    }
+                )
+            }
+        );
+        
+        // cancel the search if it takes more than 15 seconds
+        setTimeout(() => this.abortController.abort(), this.maxTime);
+    },
+    methods: {
+        async getMyBasket(url) {
+            let response = await fetch(url);
+            if (response.ok) {
+                let jsonData = await response.json();
+                for (let item of jsonData.data.items) {
+                    let itemRes = await fetch(item);
+                    if (itemRes.ok) {
+                        let itemJson = await itemRes.json();
+                        this.basketcontents.push(itemJson.data);
+                    }
+                }
+            }
+        },
+        basketContains(basketContents, collection, record_id) {
+            for (let item of basketContents) {
+                if (item.collection == collection && item.record_id == record_id) {
+                    return true;
+                }
+            }
+            return false;
+        },
+
+        toggleAddRemove(el, myBasket, collection, record_id) {
+            if (el.classList.value === "fas fa-2x fa-folder-plus") {
+                // we can run an add
+                basket.createItem(this.api_prefix, 'userprofile/my_profile/basket', collection, record_id).then( () => {
+                    el.classList.remove("fa-folder-plus");
+                    el.classList.add("fa-folder-minus");
+                })
+            } else {
+                // we can run a deletion
+                basket.deleteItem(this.api_prefix, 'userprofile/my_profile/basket', myBasket, collection, record_id).then( () => {
+                    el.classList.remove("fa-folder-minus");
+                    el.classList.add("fa-folder-plus");
+                })
+            }
+        },
+        toggleAdvancedSearch() {
+            let el = document.getElementById("advanced-search")
+            let ss = document.getElementById("simple-search")
+            let toggleASLink = document.getElementById("toggleASLink")
+            let toggleSSLink = document.getElementById("toggleSSLink")
+            if (el.style.display == "none"){
+                el.style.display = "block"
+                ss.style.display = "none"
+                toggleASLink.classList.add("active")
+                toggleSSLink.classList.remove("active")
+                //toggleLink.textContent = "Simple Search"
+            } else {
+                el.style.display = "none"
+                ss.style.display = "block"
+                toggleSSLink.classList.add("active")
+                toggleASLink.classList.remove("active")
+                //toggleLink.textContent = "Advanced Search"
+            }
+        },
+        setParameter(which, what) {
+            this.advancedParams[which] = what
+            let el = document.getElementById(which)
+            if (typeof what === "object") {
+                el.innerText = what.name
+                this.advancedParams[which] = what.value
+            } else {
+                el.innerText = what
+            }
+        },
+        submitAdvancedSearch() {
+            // Build the URL
+            var expressions = []
+            var anycount = 0
+            for (let i of ["1","2","3"]) {
+                let term  = this.advancedParams[`searchTerm${i}`]
+                let termList = []
+                // First figure out if there IS a search term here, then split it by space
+                if (term !== null) {
+                    termList = term.split(/\s+/)
+                }
+                // Next figure out if we're searching in a field or not
+                if (this.advancedParams[`searchField${i}`] == "any" ) {
+                    if (term) {
+                        console.log(term)
+                        anycount++
+                    }
+                    // What kind of search are we doing?
+                    switch (this.advancedParams[`searchType${i}`]) {
+                        case "any":
+                            // Any of the words in any field
+                            // expressions.push(termList.join(" "))
+                            // break
+                            this.reportError('"Any of the words" "in any field" is not currently supported');
+                            throw new Error("Search cancelled");
+                        case "all":
+                            // All of the words in any field
+                            expressions.push(termList.join(" "))
+                            break
+                        case "exact":
+                            // Exact phrase in any field
+                            expressions.push(`'${termList.join(" ")}'`)
+                            break
+                        case "partial":
+                            // Partial phrase in any field
+                            expressions.push(`"${termList.join(" ")}"`)
+                            break
+                        case "regex":
+                            // This can't be done like this on MDB, so we should disable the option
+                            //break
+                            this.reportError('"Regular expression" "in any field" is not currently supported');
+                            throw new Error("Search cancelled");
+                        default:
+                            expressions.push(termList.join(" "))
+                    }                    
+                } else {
+                    let myField = this.advancedParams[`searchField${i}`]
+                    let myExpr = []
+                    // To do: add a flag for case insensitive search
+                    switch(this.advancedParams[`searchType${i}`]) {
+                        case "any":
+                            // Any of the words in any field
+                            for (let term of termList) {
+                                myExpr.push(`${myField}:${term}`)
+                            }
+                            expressions.push(myExpr.join(" OR "))
+                            break
+                        case "all":
+                            // All of the words in any field
+                            expressions.push(`${myField}:${termList.join(" ")}`)
+                            break
+                        case "exact":
+                            // Exact phrase in any field
+                            expressions.push(`${myField}:'${termList.join(" ")}'`)
+                            break
+                        case "partial":
+                            // Partial phrase in any field
+                            expressions.push(`${myField}:"${termList.join(" ")}"`)
+                            break
+                        case "regex":
+                            // Regular expression; this probably needs additional validation to make sure it IS a regex
+                            // Also it doesn't work quite right...
+                            expressions.push(`${myField}:${termList.join(" ")}`)
+                            break
+                        default:
+                            expressions.push(termList.join(" "))
+                    }
+                }
+            }
+            if (anycount > 1) {                  
+                this.reportError("Can't have more than one \"in any field\" term")
+                throw new Error("Search cancelled");
+            }
+            this.expressions = expressions
+            let compiledExpr = []
+            if (this.vcoll) {
+                compiledExpr.push(`${this.vcoll} AND`)
+            }
+            for (let i in expressions) {
+                let j = parseInt(i)+1
+                let accessor = `searchConnector${j.toString()}`
+                //console.log(i, expressions[i], accessor, this.advancedParams[accessor])
+                if (expressions[i] !== "") {
+                    compiledExpr.push(expressions[i])
+                }
+                if (this.advancedParams[accessor]) {
+                    compiledExpr.push(this.advancedParams[accessor])
+                }
+            }
+            // Get rid of any trailing boolean connectors if they don't connect to another expression
+            while (compiledExpr[compiledExpr.length - 1] === 'AND') {
+                compiledExpr.pop()
+            }
+            while (compiledExpr[compiledExpr.length - 1] === 'OR') {
+                compiledExpr.pop()
+            }
+
+            // Catch and warn of invalid searches
+            // ...
+
+            let url = `${this.action}?q=${encodeURIComponent(compiledExpr.join(" "))}`
+            
+            window.location = url
+        },
+        reportError(message) {
+            let display = document.getElementById("results-spinner");
+            display = display || document.getElementById("message-display");
+            display.innerText = message;
+            this.results = []; // clear any exisiting results
+            document.getElementById("result-count-top").innerHTML = "0";
+            document.getElementById("result-count-bottom").innerHTML = "0";
+        },
+        cancelSearch() {
+            this.abortController.abort();
+            this.start = this.end = 0;
+        }
+    },
+    components: {
+        'sortcomponent': sortcomponent, 
+        'countcomponent': countcomponent
+    }
+}

--- a/dlx_rest/static/js/auth_review.js
+++ b/dlx_rest/static/js/auth_review.js
@@ -32,9 +32,9 @@ export let authreviewcomponent = {
         </div>
         <div id="filters" class="col text-center">
             Filter: 
-            <a v-for="headFilter in headFilters" class="badge badge-primary mx-1 head-filter" :data-searchString="headFilter">{{headFilter}}</a>
+            <a v-for="headFilter in headFilters" class="badge badge-light mx-1 head-filter" :data-searchString="headFilter">{{headFilter}}</a>
         </div>
-        <sortcomponent v-bind:uibase="uibase" v-bind:collection="collection" v-bind:params="params"></sortcomponent>
+        <sortcomponent v-bind:uibase="uibase" v-bind:collection="collection" v-bind:params="params"></sortcomponent>    
         <nav>
             <ul class="pagination pagination-md justify-content-center">
                 <li class="page-item disabled">

--- a/dlx_rest/static/js/auth_review.js
+++ b/dlx_rest/static/js/auth_review.js
@@ -27,7 +27,7 @@ export let authreviewcomponent = {
     <div class="col-sm-8 pt-2" id="app1" style="background-color:white;">
         <div class="col text-center">
             <h1>Authorities Review</h1>
-            Authorities creaded/updated since 
+            Authorities creaded/updated since {{since}}
             <br>
         </div>
         <div id="filters" class="col text-center">
@@ -113,6 +113,11 @@ export let authreviewcomponent = {
                 myProps[thisParam[0]] = decodeURIComponent(thisParam[1]).replace(/\+/g, ' ');
             }
         }
+        console.log(myProps["search"])
+
+        // Get the date string we want to display
+        let updated = myProps["search"].split(/updated(>|<|=)/)[2].split(" ")[0]
+        
         let myUIBase = this.api_prefix.replace('/api/','');
         //console.log(this.links)
         return {
@@ -135,7 +140,8 @@ export let authreviewcomponent = {
             searchTime: 0,
             maxTime: 15000, //milliseconds
             abortController: new AbortController(),
-            headFilters: ['110','111','150','190']
+            headFilters: ['110','111','150','190'],
+            since: updated
         }
     },
     created: async function() {
@@ -355,9 +361,22 @@ export let authreviewcomponent = {
     },
     methods: {
         rebuildUrl(param, value) {
-            //let myUrl = `${this.uibase}/records/${this.collection}/search`;
             let myParams = Object.assign({},this.params);
-            myParams[param] = value;
+            let searchParam = myParams["search"]
+            let newSearchParam = ""
+            for (let hf of this.headFilters) {
+                newSearchParam = searchParam.replace(hf, "nnn")
+                if (newSearchParam.includes("nnn")) {
+                    break
+                }
+            }
+            
+            if (newSearchParam.includes("nnn")) {
+                myParams["search"] = newSearchParam.replace("nnn",value)
+            } else {
+                myParams["search"] = `${newSearchParam} AND ${value}:*`
+            }
+
             const qs = Object.keys(myParams)
                 .map(key => `${key.replace('search','q')}=${encodeURIComponent(myParams[key])}`)
                 .join('&');

--- a/dlx_rest/static/js/auth_review.js
+++ b/dlx_rest/static/js/auth_review.js
@@ -147,7 +147,7 @@ export let authreviewcomponent = {
             searchTime: 0,
             maxTime: 15000, //milliseconds
             abortController: new AbortController(),
-            headFilters: ['100','110','111','150','190'],
+            headFilters: ['100','110','111', '130', '150','190'],
             since: updated
         }
     },

--- a/dlx_rest/static/js/auth_review.js
+++ b/dlx_rest/static/js/auth_review.js
@@ -27,8 +27,15 @@ export let authreviewcomponent = {
     <div class="col-sm-8 pt-2" id="app1" style="background-color:white;">
         <div class="col text-center">
             <h1>Authorities Review</h1>
-            Authorities creaded/updated since {{since}}
-            <br>
+            <form :action="action">  
+                <label for="dateSelector">Authorities creaded/updated since</label>              
+                <div class="input-group mb-3">
+                    <input id="dateSelector" type="date" class="form-control" aria-label="Date" :value="since">
+                    <div class="input-group-append">
+                        <a class="btn btn-outline-secondary" type="button" @click="changeDateAndSearch">Submit</a>
+                    </div>
+                </div>
+            </form>
         </div>
         <div id="filters" class="col text-center">
             Filter: 
@@ -140,7 +147,7 @@ export let authreviewcomponent = {
             searchTime: 0,
             maxTime: 15000, //milliseconds
             abortController: new AbortController(),
-            headFilters: ['110','111','150','190'],
+            headFilters: ['100','110','111','150','190'],
             since: updated
         }
     },
@@ -356,7 +363,7 @@ export let authreviewcomponent = {
         setTimeout(() => this.abortController.abort(), this.maxTime);
 
         for (let el of document.getElementsByClassName('head-filter')) {
-            el.href = this.rebuildUrl(el.id, el.getAttribute("data-searchString"));
+            el.href = this.rebuildUrl("search", el.getAttribute("data-searchString"));
         }
     },
     methods: {
@@ -573,6 +580,31 @@ export let authreviewcomponent = {
         cancelSearch() {
             this.abortController.abort();
             this.start = this.end = 0;
+        },
+        changeDateAndSearch() {
+            // this.action is where we start
+            let myParams = Object.assign({},this.params);
+            let newDate = document.getElementById("dateSelector").value
+            //el.href = this.rebuildUrl("updated", el.getAttribute("data-searchString"));
+            let searchParam = myParams["search"]
+            let newSearchParams = []
+            //let newSearchParam = searchParam.replace("updated", newDate)
+            for (let p of searchParam.split(" ")) {
+                let newP = p
+                if (p.includes("updated")) {
+                    let v = p.split(/(<|=|>)/)
+                    newP = p.replace(v[2],newDate)
+                }
+                newSearchParams.push(newP)
+            }
+                
+            myParams["search"] = newSearchParams.join(" ")
+            console.log(myParams)
+        
+            const qs = Object.keys(myParams)
+                .map(key => `${key.replace('search','q')}=${encodeURIComponent(myParams[key])}`)
+                .join('&');
+            window.location = `${this.action}?${qs}`;
         }
     },
     components: {

--- a/dlx_rest/static/js/auth_review_vm.js
+++ b/dlx_rest/static/js/auth_review_vm.js
@@ -1,0 +1,22 @@
+/////////////////////////////////////////////////////////////////
+// Imports
+/////////////////////////////////////////////////////////////////
+
+//import { Jmarc } from "./jmarc.mjs";
+import { messagecomponent } from "./messagebar.js";
+import { sidebarcomponent } from "./search/sidebar.js";
+import { authreviewcomponent } from "./auth_review.js";
+//import { browsecomponent } from "./search/browse.js";
+
+
+/////////////////////////////////////////////////////////////////
+// VIEW MODEL DEFINITION
+/////////////////////////////////////////////////////////////////
+export let auth_review_vm = new Vue({
+    el: '#auth_review_vm',
+    components: { messagecomponent, sidebarcomponent, authreviewcomponent },//, browsecomponent },
+    data: {
+      visible: false,
+    },
+    methods: {}
+})

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -611,13 +611,15 @@ export let multiplemarcrecordcomponent = {
             newSubfield.value = "t"
             newField = this.buildFieldRow(newField);
             newField.tagSpan.focus();
-            document.execCommand("selectall");
+            //document.execCommand("selectall");
             newField.subfields[0].valueCell.classList.add("unsaved");
 
             // Manage visual indicators
             jmarc.saveButton.classList.add("text-danger");
             jmarc.saveButton.classList.remove("text-primary");
             jmarc.saveButton.title = "Save Record";
+
+            jmarc.addUndoredoEntry("from Approve Auth")
         },
 
         ///////////////////////////////////////////////////

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -619,6 +619,7 @@ export let multiplemarcrecordcomponent = {
             jmarc.saveButton.classList.remove("text-primary");
             jmarc.saveButton.title = "Save Record";
 
+            // Is this the way this works?
             jmarc.addUndoredoEntry("from Approve Auth")
         },
 

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -591,6 +591,21 @@ export let multiplemarcrecordcomponent = {
                 })
             }
         },
+        approveAuth(jmarc) {
+            this.selectedFields.push
+            let newField = jmarc.createField("999")
+            let newSubfield = newField.createSubfield("c")
+            newSubfield.value = "t"
+            newField = this.buildFieldRow(newField);
+            newField.tagSpan.focus();
+            document.execCommand("selectall");
+            newField.subfields[0].valueCell.classList.add("unsaved");
+
+            // Manage visual indicators
+            jmarc.saveButton.classList.add("text-danger");
+            jmarc.saveButton.classList.remove("text-primary");
+            jmarc.saveButton.title = "Save Record";
+        },
 
         //////////////////////////////////////////////////////// 
         ///// definition of the listeners for the shortcuts
@@ -1496,6 +1511,12 @@ export let multiplemarcrecordcomponent = {
                     {"name": "revertButton", "element": "i", "class": "fa fa-undo", "title": "Revert",  "click": "revert"},
                     {"name": "removeButton", "element": "i", "class": "fas fa-window-close float-right", "title": `Close Record`, "click": "removeRecordFromEditor"}
                 ]
+            }
+
+            if (jmarc.collection =="auths") {
+                controls.push(
+                    {"name": "approveAuthButton", "element": "i", "class": "fas fa-check-circle", "title": "Approve Record", "click": "approveAuth"}
+                )
             }
 
             if (this.readonly && this.user !== null) {

--- a/dlx_rest/templates/base.html
+++ b/dlx_rest/templates/base.html
@@ -66,7 +66,16 @@
                     <li class="nav-item"><a class="nav-link" href="{{url_for('get_records_list', coll='bibs')}}">Bibs</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{url_for('search_records', coll='bibs', q="989:Speeches")}}">Speeches</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{url_for('search_records', coll='bibs', q="989:Voting Data")}}">Votes</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{url_for('get_records_list', coll='auths')}}">Auths</a></li>
+                    <!-- <li class="nav-item"><a class="nav-link" href="{{url_for('get_records_list', coll='auths')}}">Auths</a></li> -->
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            Auths
+                          </a>
+                          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                            <a class="dropdown-item" href="{{url_for('get_records_list', coll='auths')}}">Auths</a>
+                            <a class="dropdown-item" href="{{url_for('review_auth')}}">Review Auths</a>
+                          </div>
+                    </li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                           Browse

--- a/dlx_rest/templates/review_auths.html
+++ b/dlx_rest/templates/review_auths.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %} {% block content %}    
+
+    <div id="auth_review_vm" v-show="true" data-api_prefix="{{api_prefix}}">
+        <headercomponent></headercomponent>
+        <messagecomponent prefix="{{api_prefix}}"></messagecomponent>
+        <div class="row">
+            <sidebarcomponent sbtype="facet"></sidebarcomponent>
+            <authreviewcomponent api_prefix="{{api_prefix}}" search_url="{{search_url}}" logged_in="{{'1' if current_user.is_authenticated else ''}}"></authreviewcomponent>
+            <sidebarcomponent sbtype="other"></sidebarcomponent>
+        </div>
+    </div>
+
+<script type="module" src="{{url_for('static', filename='js/auth_review_vm.js')}}" ></script>
+
+{% endblock %}

--- a/dlx_rest/templates/review_auths.html
+++ b/dlx_rest/templates/review_auths.html
@@ -1,11 +1,10 @@
 {% extends 'base.html' %} {% block content %}    
 
     <div id="auth_review_vm" v-show="true" data-api_prefix="{{api_prefix}}">
-        <headercomponent></headercomponent>
         <messagecomponent prefix="{{api_prefix}}"></messagecomponent>
         <div class="row">
             <sidebarcomponent sbtype="facet"></sidebarcomponent>
-            <authreviewcomponent api_prefix="{{api_prefix}}" search_url="{{search_url}}" logged_in="{{'1' if current_user.is_authenticated else ''}}"></authreviewcomponent>
+            <authreviewcomponent api_prefix="{{api_prefix}}" search_url="{{search_url}}" logged_in="{{'1' if current_user.is_authenticated else ''}}" collection="{{collection}}" since="{{since}}"></authreviewcomponent>
             <sidebarcomponent sbtype="other"></sidebarcomponent>
         </div>
     </div>

--- a/dlx_rest/tests/conftest.py
+++ b/dlx_rest/tests/conftest.py
@@ -140,8 +140,11 @@ def roles(permissions):
             this_permission.save()
             coll_perms.append(this_permission)
         if coll == "auths":
+            auth_review = Permission(action="reviewAuths", constraint_must=['auths'])
+            auth_review.save()
             merge_auth = Permission(action="mergeAuthority", constraint_must=["auths"])
             merge_auth.save()
+            coll_perms.append(auth_review)
             coll_perms.append(merge_auth)
         # collection role
         coll_admin = Role(name=f'{coll}-admin')

--- a/dlx_rest/tests/conftest.py
+++ b/dlx_rest/tests/conftest.py
@@ -122,6 +122,11 @@ def roles(permissions):
             this_permission = Permission(action=f'{action}{comp}')
             this_permission.save()
             admin_permissions.append(this_permission)
+
+    # Special case that doesn't fit the above
+    merge_auth = Permission(action="mergeAuthority")
+    merge_auth.save()
+    admin_permissions.append(merge_auth)
     
     admin_role = Role(name="admin")
     admin_role.permissions = admin_permissions
@@ -134,6 +139,10 @@ def roles(permissions):
             this_permission = Permission(action=f'{action}Record', constraint_must=[f'{coll}'])
             this_permission.save()
             coll_perms.append(this_permission)
+        if coll == "auths":
+            merge_auth = Permission(action="mergeAuthority", constraint_must=["auths"])
+            merge_auth.save()
+            coll_perms.append(merge_auth)
         # collection role
         coll_admin = Role(name=f'{coll}-admin')
         coll_admin.permissions = coll_perms


### PR DESCRIPTION
Fixes #373 

Creates a new endpoint at /records/auths/review 
* Lists authority records that were updated since a default start date (currently 2022-03-01, to be configurable later)
* Provides heading based filters (need advice on which 1xx fields to include)
* Allows selection of a new start date, which performs a search on updated>[date]
* Otherwise acts as a regular search results page without a specific search bar

Also creates a new record control "reviewAuth", which appends to the record a new 999__c field with a value of 't' (this can be changed if we want something else)

Finally, creates a new menu entry in the main site menu, adding a dropdown option on the Auths link. 