### PR TITLE
attempt auth delete before removing record from basket

### DIFF
--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -583,14 +583,13 @@ export let multiplemarcrecordcomponent = {
                     let deletedRid = jmarc.recordId;
                     let deletedColl = jmarc.collection;
  
-                    this.$root.$refs.basketcomponent.removeRecordFromList(jmarc.collection, jmarc.recordId).then( () => {
-                        jmarc.delete().then( () => {
-                            this.removeRecordFromEditor(jmarc);
-                            this.callChangeStyling(`Record ${deletedColl}/${deletedRid} has been deleted`, "row alert alert-success");
-                        }).catch( error => {
-                            this.callChangeStyling(error.message,"row alert alert-danger");
-                        });
-                    })
+                    jmarc.delete().then( () => {
+                        this.removeRecordFromEditor(jmarc);
+                        this.callChangeStyling(`Record ${deletedColl}/${deletedRid} has been deleted`, "row alert alert-success");
+                        this.$root.$refs.basketcomponent.removeRecordFromList(jmarc.collection, jmarc.recordId)
+                    }).catch( error => {
+                        this.callChangeStyling(error.message,"row alert alert-danger");
+                    });
                 }
             }
  

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -586,7 +586,8 @@ export let multiplemarcrecordcomponent = {
                     jmarc.delete().then( () => {
                         this.removeRecordFromEditor(jmarc);
                         this.callChangeStyling(`Record ${deletedColl}/${deletedRid} has been deleted`, "row alert alert-success");
-                        this.$root.$refs.basketcomponent.removeRecordFromList(jmarc.collection, jmarc.recordId)
+                        //this.$root.$refs.basketcomponent.removeRecordFromList(jmarc.collection, jmarc.recordId)
+                        this.$root.$refs.basketcomponent.rebuildBasket()
                     }).catch( error => {
                         this.callChangeStyling(error.message,"row alert alert-danger");
                     });


### PR DESCRIPTION
Fixes #493 

This switches the order a bit when record deletion is requested so that the item is not removed from the user's basket if an error occurs. This includes 403 errors because either the user doesn't have authorization to delete the record or because it's an in-use authority record.