### PR TITLE
remove check that fails for new records before they reload

### DIFF
--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -541,21 +541,17 @@ export class Jmarc {
 				return response.json()
 			}
 		)
-        /*
         .then(
 			check => {
-                console.log(check)
-				if (check.constructor.name == "Jmarc") {
-					return check
+				if (! check instanceof Jmarc) {
+					throw new Error(`Something went wrong: ${check}`)
 				}
 				
-				throw new Error(check['message'])
+				return check
 			}
 		)
-        */
         .catch(
-			// error => console.error(error)
-			error => { throw new Error(error) }
+			error => {throw error}
 		)
 	}
 

--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -540,15 +540,20 @@ export class Jmarc {
 				
 				return response.json()
 			}
-		).then(
+		)
+        /*
+        .then(
 			check => {
+                console.log(check)
 				if (check.constructor.name == "Jmarc") {
 					return check
 				}
 				
 				throw new Error(check['message'])
 			}
-		).catch(
+		)
+        */
+        .catch(
 			// error => console.error(error)
 			error => { throw new Error(error) }
 		)


### PR DESCRIPTION
Fixes #573 

But it's unclear what this check is doing, and why it's necessary. If it is necessary, it would be better to fix the issue that causes the check to fail in the first place.