### PR TITLE
Preserve existing objects in Jmarc data parser to improve unsaved changes detection

### DIFF
--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -782,7 +782,7 @@ export class Jmarc {
 	
 
 	getFields(tag) {
-		return this.fields.filter(x => x.tag == tag);
+		return this.fields.filter(x => x.tag == tag)
 	}
 	
 	getField(tag, place) {

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ itsdangerous==2.1.2
 Jinja2==3.1.1
 jmespath==1.0.0
 jsonschema==4.0.0
-lxml==4.8.0
+lxml==4.9.1
 MarkupSafe==2.1.1
 mongoengine==0.24.1
 mongomock==3.23.0


### PR DESCRIPTION
Enables unsaved changes detection even if the data is re-parsed, as in when data is refreshed from a previous state in the undo/redo stack.

closes #640 