### PR TITLE
669

### DIFF
--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -2509,6 +2509,9 @@ export let multiplemarcrecordcomponent = {
                 // strip newlines and multispaces
                 valSpan.innerText = valSpan.innerText.replace(/\r?\n|\r/g, " ");
                 valSpan.innerText = valSpan.innerText.replace(/ {2,}/g, " ");
+
+                // do the update and checks
+                checkState();
             });
 
             valSpan.addEventListener("focus", function() {


### PR DESCRIPTION
closes #669 

The paste event listener was not updating the jmarc, so the field was being saved without a subfield value





