### PR TITLE
Update URL with current records

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -1223,7 +1223,7 @@ class RecordMerge(Resource):
                         # we can skip the auth validation for now because it's done in the front end
                         record.commit(user=user.username if user else 'admin', auth_check=False)
 
-                    if Config.TESTING:
+                    if 1: #Config.TESTING:
                         # the threading doesn't work here in pytest
                         record.commit(user=user.username if user else 'admin', auth_check=False)
                     else:

--- a/dlx_rest/static/js/merge.js
+++ b/dlx_rest/static/js/merge.js
@@ -95,8 +95,6 @@ export let modalmergecomponent = {
      this.toggleModal();
      window.alert("The authorities merge is in process in the background");
      vm.callChangeStyling(`Authorities merge ${losing} into ${gaining} in process`,"d-flex w-100 alert-success");
-
-     window.alert("reloading")
      
      // wait one second then reload the editor with the auth records
      setTimeout(() => {

--- a/dlx_rest/static/js/merge.js
+++ b/dlx_rest/static/js/merge.js
@@ -95,10 +95,12 @@ export let modalmergecomponent = {
      this.toggleModal();
      window.alert("The authorities merge is in process in the background");
      vm.callChangeStyling(`Authorities merge ${losing} into ${gaining} in process`,"d-flex w-100 alert-success");
+
+     window.alert("reloading")
      
      // wait one second then reload the editor with the auth records
      setTimeout(() => {
-      let updatedUrl = location.href.replace(/\/editor\?.*/, `/editor?records=auths/${losing},auths/${gaining}`);
+      let updatedUrl = location.href.replace(/\/editor.*/, `/editor?records=auths/${losing},auths/${gaining}`);
       location.replace(updatedUrl);
      }, 1000);
    }

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -1555,11 +1555,16 @@ export let multiplemarcrecordcomponent = {
  
             this.addJmarcTodisplayedJmarcObject(jmarc);
 
+            // keep list of records
             let recordString = `${jmarc.collection}/${jmarc.recordId}`;
 
             if (! this.recordlist.includes(recordString)) {
                 this.recordlist.push(recordString)
             }
+
+            // update URL with current open records
+            let updatedUrl = location.href.replace(/\/editor.*/, `/editor?records=${this.recordlist.join(",")}`);
+            window.history.replaceState({}, null, updatedUrl);
 
             //////////////////////////////////////////////////////////////////////////////
             // optimize the display just when you have one record displayed

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cfn-flip==1.3.0
 charset-normalizer==2.0.12
 click==8.1.2
 cryptography==36.0.2
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@33f97a0f89720f01e326891d5651b2e34b334e56
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@6239a25b004fc47f622276e8db793cb805c6e6ae
 dnspython==2.2.1
 email-validator==1.1.3
 Flask==2.1.1


### PR DESCRIPTION
close #638 

Update the current URL to reflect the current open records, so that the records remain in the editor if the page is reloaded