### PR TITLE
Browse index bugfix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cfn-flip==1.3.0
 charset-normalizer==2.0.12
 click==8.1.2
 cryptography==36.0.2
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@d2d51e60f475800b915319233c7061605e7341d9
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@9f009fc48ab85a3986e5921ab24e1224758a27e6
 dnspython==2.2.1
 email-validator==1.1.3
 Flask==2.1.1


### PR DESCRIPTION
closes #701 

Removes obsolete values from browse index on record update. Note this will not remove any already existing obsolete browse index values in the database.