### PR TITLE
use session to keep sort/dir variables

### DIFF
--- a/dlx_rest/app.py
+++ b/dlx_rest/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, Response, url_for, jsonify, abort as flask_abort
+from flask import Flask, Response, url_for, jsonify, abort as flask_abort, session
 #from flask_restx import Resource, Api, reqparse
 from flask_login import LoginManager
 from pymongo import ASCENDING as ASC, DESCENDING as DESC

--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -419,23 +419,34 @@ def search_records(coll):
     start = request.args.get('start', 1)
     q = request.args.get('q', '')
 
+    session.permanent = True
+
+    # Move vcoll variable here so we can use it in the session 
+    vcoll = coll
+    if "B22" in q:
+        vcoll = "speeches"
+    if "B23" in q:
+        vcoll = "votes"
+
     sort =  request.args.get('sort')
     direction = request.args.get('direction') #, 'desc' if sort == 'updated' else '')
 
     if sort and direction:
         # Regardless of what's in the session already
-        session["sortCollectionFieldDirection"] = {coll: {"field": sort, "direction": direction}}
-        #print(f"Set {session['sortCollectionFieldDirection']} from URL")
+        session[f"sort_{vcoll}"] = {"field": sort, "direction": direction}
+        this_v = session[f"sort_{vcoll}"]
+        print(f"Got {this_v} from URL")
     else:
         # See if something is in the session already
         try:
             # We have session values, so use those
-            #print(f"Got {session['sortCollectionFieldDirection']} from session")
-            sort = session["sortCollectionFieldDirection"][coll]["field"]
-            direction = session["sortCollectionFieldDirection"][coll]["direction"]
+            this_v = session[f"sort_{vcoll}"]
+            print(f"Got {this_v} from session")
+            sort = session[f"sort_{vcoll}"]["field"]
+            direction = session[f"sort_{vcoll}"]["direction"]
         except KeyError:
             # There is nothing in the session, so fallback to defaults
-            #print("Defaults ....")
+            print(f"No sort/dir for {vcoll} found, using defaults.")
             sort = "updated"
             direction = "desc"
     
@@ -454,12 +465,6 @@ def search_records(coll):
  
 
     search_url = url_for('api_records_list', collection=coll, start=start, limit=limit, sort=sort, direction=direction, search=q, _external=True, format='brief')
-
-    vcoll = coll
-    if "B22" in q:
-        vcoll = "speeches"
-    if "B23" in q:
-        vcoll = "votes"
 
     # todo: get all from dlx config
     # Sets the list of logical field indexes that should appear in advanced search

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ Flask-Cors==3.0.10
 Flask-Login==0.6.0
 flask-mongoengine==1.0.0
 flask-restx==0.5.1
+Flask-Session==0.4.0
 Flask-WTF==1.0.1
 idna==3.3
 importlib-metadata==4.11.3


### PR DESCRIPTION
Closes #516 

This keeps session variables for the sort and direction based on the collection headings. A user can have one sort/direction combo per collection (bibs, auths, speeches, votes). If the user chooses something else (e.g., clicks the sort field/directions at the top of the search page), the session will store the new values.