### PR TITLE
carry over indicators from linked auth

### DIFF
--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -178,6 +178,7 @@ export class DataField {
 					// the wanted auth field is the only 1XX field
 					for (let tag of Object.keys(auth).filter(x => x.match(/^1\d\d/))) {
 						let field = this instanceof BibDataField ? new BibDataField(this.tag) : new AuthDataField(this.tag);
+						field.indicators = auth[tag][0].indicators;
 						
 						for (let sf of auth[tag][0]['subfields']) {
 							field.subfields.push(new Subfield(sf['code'], sf['value'], auth['_id']));

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -2784,7 +2784,7 @@ export let multiplemarcrecordcomponent = {
             let component = this;
             subfield.valueSpan.classList.add("authority-controlled");
    
-            if (subfield.valueCell.classList.contains("unsaved")) {
+            if (! "xref" in subfield) {
                 subfield.valueSpan.classList.add("authority-controlled-unmatched")
             }
  
@@ -2995,7 +2995,10 @@ function keyupAuthLookup(event) {
                        
                         item.addEventListener("mousedown", function () {
                             dropdown.remove();
- 
+                            field.ind1Span.innerText = choice.indicators[0];
+                            field.ind2Span.innerText = choice.indicators[1];
+                            field.indicators = choice.indicators.map(x => x === " " ? "_" : x);
+
                             for (let s of field.subfields) {
                                 s.valueSpan.classList.remove("authority-controlled-unmatched");
                             }
@@ -3030,6 +3033,11 @@ function keyupAuthLookup(event) {
                                     
                                 currentSubfield.xrefCell.append(xrefLink);
                             }
+
+                            // trigger update events
+                            field.ind1Span.focus();
+                            field.ind2Span.focus();
+                            field.subfields.forEach(x => x.codeSpan.focus() && x.valueSpan.focus());
                         });
                     }
                 });


### PR DESCRIPTION
closes #461 

Carries over all indicators from the auth heading field.