### PR TITLE
prevent/warn on save of duplicate auth headings

### DIFF
--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -849,6 +849,34 @@ export class Jmarc {
             }
         }
     }
+
+	async authHeadingInUse() {
+		if (this.collection !== "auths") return
+
+		let headingField = (this.fields.filter(x => x.tag.match(/^1/)) || [null])[0];
+
+		if (! headingField) return
+
+		let searchStr = 
+    	    headingField.subfields
+    	    .map(x => `${headingField.tag}__${x.code}:'${x.value}'`)
+    	    .join(" AND ");
+
+    	let url = Jmarc.apiUrl + "/marc/auths/records/count?search=" + searchStr;
+
+    	// wait for the result
+    	let inUse = await fetch(url)
+    	    .then(response => {
+    	        return response.json()
+    	    }).then(json => {
+    	        let count = json.data;
+    	        return count ? true : false
+    	    }).catch(error => {
+    	        throw error
+    	    })
+
+		return inUse ? true : false
+	}
 }
 
 export class Bib extends Jmarc {

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -436,7 +436,7 @@ export let multiplemarcrecordcomponent = {
                             if (! window.confirm(msg)) {
                                 return
                             }
-                        } else if (headingField.tag !== "100" && inUse === true) {
+                        } else if (headingField.tag !== "100" && inUse === true && isNewVal) {
                             this.callChangeStyling(`The heading "${headingString}" is already in use. Headings for records with tag ${headingField.tag} cannot be duplicated`, "d-flex w-100 alert-danger")
                             return
                         }
@@ -2930,7 +2930,7 @@ function keyupAuthLookup(event) {
     addButton.title = "Create new authority from this value";
     addButton.className = "fas fa-solid fa-plus float-left mr-2 create-authority";
 
-    addButton.addEventListener("click", function() {
+    addButton.addEventListener("click", async function() {
         subfield.xrefCell.innerHTML = null;
         let spinner = document.createElement("i");
         spinner.className = "fa fa-spinner";
@@ -2971,6 +2971,15 @@ function keyupAuthLookup(event) {
                 newSubfield = auth.createField("670").createSubfield("a");
                 newSubfield.value = jmarc.getField("791").getSubfield("a").value;
             }
+        }
+
+        if (await auth.authHeadingInUse()) {
+            let headingField = auth.fields.filter(x => x.tag.match(/^1/))[0];
+            let headingString = headingField.subfields.map(x => x.value).join(" ");
+            component.callChangeStyling(`Auth heading "${headingString}" in field ${field.tag} is already in use`, "d-flex w-100 alert-danger");
+            subfield.xrefCell.removeChild(spinner);
+            subfield.xrefCell.append(addButton);
+            return
         }
 
         auth.post().then(

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -793,6 +793,10 @@ export let multiplemarcrecordcomponent = {
                 if (confirm("Are you sure you want to delete this record ?") == true) {
                     let deletedRid = jmarc.recordId;
                     let deletedColl = jmarc.collection;
+
+                    jmarc.deleteButton.classList.add("fa-spinner");
+                    jmarc.deleteButton.classList.add("fa-pulse");
+                    jmarc.deleteButton.style = "pointer-events: none";
  
                     jmarc.delete().then( () => {
                         this.removeRecordFromEditor(jmarc);

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -390,7 +390,28 @@ export let multiplemarcrecordcomponent = {
                 }
             }
         },
-        async saveRecord(jmarc,display=true){
+        async saveRecord(jmarc, display=true){
+            // trigger all update actions in case they haven't fired yet
+            // preserve scroll location
+            let scrollX = window.scrollX;
+            let scrollY = window.scrollY;
+            let scroll = jmarc.tableBody.scrollTop;
+
+            jmarc.getDataFields().forEach(x => {
+                x.tagSpan.focus();
+                x.ind1Span.focus();
+                x.ind2Span.focus();
+                
+                x.subfields.forEach(y => {
+                    y.codeSpan.focus();
+                    y.valueSpan.focus();
+                    y.valueSpan.blur();
+                });
+            });
+
+            jmarc.tableBody.scrollTop = scroll;
+            window.scrollTo(scrollX, scrollY);
+
             if (jmarc.workformName) {
                 jmarc.saveWorkform(jmarc.workformName, jmarc.workformDescription).then( () => {
                     this.removeRecordFromEditor(jmarc); // div element is stored as a property of the jmarc object


### PR DESCRIPTION
closes #372 

* Authority records with duplicate personal name headings (tag 100) issue a warning on save.
* All other authority types are prevented from being saved with duplicate headings.
* Prevent new auth records with duplicate headings from being created from inside record (all auth types).
* Smalll fixes