### PR TITLE
Revert changes to space/punct handling in browse

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -454,8 +454,8 @@ class RecordsListBrowse(Resource):
         collation = Collation(
             locale='en', 
             strength=2,
-            alternate='shifted',
-            maxVariable='space' if field in numeric_fields else 'punct', # ignore punct unless sort is numeric
+            #alternate='shifted',
+            #maxVariable='space' if field in numeric_fields else 'punct', # ignore punct unless sort is numeric
             numericOrdering=True if field in numeric_fields else False
         )
         start, limit = int(args.start), int(args.limit)


### PR DESCRIPTION
The changes in #737 had unintended consequences for sorting on strings with mid-string spaces and punctuation, so this reverts to the previous behavior.