### PR TITLE
Add all visible search results to basket

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -3,6 +3,7 @@ DLX REST API
 '''
 
 # external
+from asyncio import constants
 from http.client import HTTPResponse
 import this
 from dlx_rest.routes import login, search_files
@@ -1646,6 +1647,22 @@ class MyBasketRecord(Resource):
             # The item is not locked, so we can add it to our basket
             this_u.my_basket().add_item(item)
             return {},201      
+
+@ns.route('/userprofile/my_profile/basket/addBulk')
+class MyBasketAddBulk(Resource):
+    @ns.doc("Add a list of records to the user's basket in bulk.", security="basic")
+    @login_required
+    def post(self):
+        try:
+            this_u = User.objects.get(id=current_user['id'])
+            user_id = this_u['id']
+            this_basket = Basket.objects(owner=this_u)[0]
+            items = json.loads(request.data)
+            if items:
+                this_basket.add_items(items)
+        except:
+            raise
+        return 200
 
 @ns.route('/userprofile/my_profile/basket/clear')
 class MyBasketClear(Resource):

--- a/dlx_rest/models.py
+++ b/dlx_rest/models.py
@@ -171,6 +171,27 @@ class Basket(Document):
             self.items.append(item)
             self.save()
 
+    def add_items(self, items):
+        insert_items = []
+        for item in items:
+            ulid = ULID()
+            existing_item = None
+            try:
+                existing_item = self.get_item_by_coll_and_rid(item['collection'], item['record_id'])
+            except IndexError:
+                pass
+
+            if existing_item is None:
+                insert_items.append({
+                    "id": str(ulid.to_uuid()),
+                    "collection": item['collection'],
+                    "record_id": item['record_id'],
+                    "title": "[No Title]",
+                    "override": False
+                })
+        self.items = insert_items
+        self.save()
+
     def remove_item(self, item_id):
         #self.items = list(filter(lambda x: x['collection'] != item['collection'] and x['record_id'] != item['record_id'], self.items))
         this_item = self.get_item_by_id(item_id)

--- a/dlx_rest/static/js/api/basket.js
+++ b/dlx_rest/static/js/api/basket.js
@@ -36,11 +36,12 @@ export default {
             fetch(url, {
                 method: 'POST',
                 body: data
-            }).then( () => {
-                //console.log("and we did")
-                return true;
-            });
+            }).catch( e => {
+                console.log(e)
+            })
         });
+
+        return true
     },
     async getItem(api_prefix, collection, record_id) {
         Jmarc.api_prefix = api_prefix;
@@ -76,8 +77,9 @@ export default {
         const returnData = new Set(jsonData.data.item_data.sort((a,b) => a - b))
         return returnData;
     },
-    clearItems(api_prefix, basket_id='userprofile/my_profile/basket') {
-        let url = `${api_prefix}/${basket_id}`
+    async clearItems(api_prefix, basket_id='userprofile/my_profile/basket') {
+        let url = `${api_prefix}${basket_id}/clear`
+        await fetch(url, {method:"POST"}).then(() => {return true} )
     },
     contains(collection, record_id, basket) {
         for (let item of basket) {

--- a/dlx_rest/static/js/api/basket.js
+++ b/dlx_rest/static/js/api/basket.js
@@ -2,46 +2,23 @@ import { Jmarc } from "../jmarc.mjs";
 
 export default {
     // Individual item methods
-    async createItem(api_prefix, basket_id='userprofile/my_profile/basket', collection, record_id, override=false) {
-        
-        Jmarc.apiUrl = api_prefix;
+    async createItem(api_prefix, basket_id='userprofile/my_profile/basket', collection, record_id, override=false) {        
         let url = `${api_prefix}${basket_id}`;
-        let myItemTitle = "";
-        let myId = null;
-        // Check here to see if the record is already in another basket? Return that fact, along with the user?
-        Jmarc.get(collection, record_id).then(jmarc => {
-            if(collection == "bibs") {
-                let myTitleField = jmarc.getField(245,0);
-                let myTitle = [];
-                if (myTitleField) {
-                    for (let s in myTitleField.subfields) {
-                        myTitle.push(myTitleField.subfields[s].value);
-                    }
-                } else {
-                    myTitle.push("[No Title]")
-                }
-                
-                myItemTitle = myTitle.join(" ").replace(/"/g, `\\"`);
-            } else if (collection == "auths") {
-                //console.log("Trying to create an auth basket item...")
-                let myTitleField = jmarc.fields.filter(x => x.tag.match(/^1[0-9][0-9]/))[0];
-                let myTitle = [];
-                for (let s in myTitleField.subfields) {
-                    myTitle.push(myTitleField.subfields[s].value);
-                }
-                myItemTitle = myTitle.join(" ").replace(/"/g, `\\"`);
-            }
-            let data = `{"collection": "${collection}", "record_id": "${record_id}", "title": "${myItemTitle}", "override": ${override}}`
-            //console.log(url)
-            fetch(url, {
-                method: 'POST',
-                body: data
-            }).catch( e => {
-                console.log(e)
-            })
-        });
+        let data = `{"collection": "${collection}", "record_id": "${record_id}", "title": "[No Title]", "override": ${override}}`
+
+        await fetch(url, {
+            method: 'POST',
+            body: data
+        })
 
         return true
+    },
+    async createItems(api_prefix, basket_id='userprofile/my_profile/basket', items) {
+        let url = `${api_prefix}${basket_id}/addBulk`;
+        if (items.length > 0) {
+            await fetch(url, {method: "POST", body: items})
+            return true
+        }
     },
     async getItem(api_prefix, collection, record_id) {
         Jmarc.api_prefix = api_prefix;

--- a/dlx_rest/static/js/basket.js
+++ b/dlx_rest/static/js/basket.js
@@ -130,9 +130,9 @@ export let basketcomponent = {
             }
         },
         async clearBasket() {
-            for (let item of this.basketItems) {
-                this.removeRecordFromList(item.collection, item._id)
-            }
+            basket.clearItems(this.api_prefix, "userprofile/my_profile/basket").then(() => {
+                this.rebuildBasket()
+            })
         },
         async buildBasket() {
             const myBasket = await basket.getBasket(this.api_prefix);

--- a/dlx_rest/static/js/search/search.js
+++ b/dlx_rest/static/js/search/search.js
@@ -524,22 +524,6 @@ export let searchcomponent = {
             }
             return false;
         },
-
-        toggleAddRemove(el, myBasket, collection, record_id) {
-            if (el.classList.value === "fas fa-2x fa-folder-plus") {
-                // we can run an add
-                basket.createItem(this.api_prefix, 'userprofile/my_profile/basket', collection, record_id).then( () => {
-                    el.classList.remove("fa-folder-plus");
-                    el.classList.add("fa-folder-minus");
-                })
-            } else {
-                // we can run a deletion
-                basket.deleteItem(this.api_prefix, 'userprofile/my_profile/basket', myBasket, collection, record_id).then( () => {
-                    el.classList.remove("fa-folder-minus");
-                    el.classList.add("fa-folder-plus");
-                })
-            }
-        },
         async handleIconClick(e) {
             let collection = e.target.id.split("-")[1]
             let record_id = e.target.id.split("-")[2]
@@ -722,29 +706,37 @@ export let searchcomponent = {
             this.abortController.abort();
             this.start = this.end = 0;
         },
-        selectAll()  {
+        selectAll(e)  {
+            e.preventDefault()
             for (let inputEl of document.getElementsByTagName("input")) {
                 if (inputEl.type == "checkbox" && !inputEl.disabled) {
                     inputEl.checked = true
                 }
             }
         },
-        selectNone() {
+        selectNone(e) {
+            e.preventDefault()
             for (let inputEl of document.getElementsByTagName("input")) {
                 if (inputEl.type == "checkbox") {
                     inputEl.checked = false
                 }
             }
         },
-        async sendToBasket() {
+        async sendToBasket(e) {
+            e.preventDefault()
+            let items = []
             for (let inputEl of document.getElementsByTagName("input")) {
                 if (inputEl.type == "checkbox" && inputEl.checked) {
                     let collection = inputEl.id.split("-")[1]
                     let record_id = inputEl.id.split("-")[2]
-                    let iconEl = document.getElementById(`icon-${collection}-${record_id}`)
-                    iconEl.click()
-                    //console.log(collection, record_id)
+                    items.push({
+                        "collection": `${collection}`,
+                        "record_id": `${record_id}`
+                    })
                 }
+            }
+            if (items.length > 0) {
+                basket.createItems(this.api_prefix, 'userprofile/my_profile/basket', JSON.stringify(items)).then( () => window.location.reload(false) )
             }
         }
     },

--- a/dlx_rest/static/js/search/search.js
+++ b/dlx_rest/static/js/search/search.js
@@ -148,9 +148,16 @@ export let searchcomponent = {
         </div>
         <br>
         <div id="message-display" class="col-xs-1 text-center"></div>
+        <div class="row">
+            Select 
+            <a class="mx-1" href="#" @click="selectAll">All</a>
+            <a class="mx-1" href="#" @click="selectNone">None</a>
+            <a class="mx-1" href="#" @click="sendToBasket">Send Selected to Basket</a>
+        </div>
         <div id="results-list" v-for="result in this.results" :key="result._id">
             <div class="row mt-1 bg-light border-bottom">
-                <div class="col-sm-11 px-4 ">
+                <div class="col-sm-1"><input :id="'input-' + collection + '-' + result._id" type="checkbox" disabled="true" data-toggle="tooltip" title="Select/deselect record"/></div>
+                <div class="col-sm-10 px-4 ">
                     <div class="row" style="overflow-x:hidden">
                         <a v-if="allowDirectEdit" :id="'link-' + result._id" class="result-link" :href="uibase + '/editor?records=' + collection + '/' + result._id" style="white-space:nowrap">{{result.first_line}}</a>
                         <a v-else class="result-link" :id="'link-' + result._id" :href="uibase + '/records/' + collection + '/' + result._id" style="white-space:nowrap">{{result.first_line}}</a>
@@ -163,7 +170,7 @@ export let searchcomponent = {
                 <div class="col-sm-1">
                     <!-- need to test if authenticated here -->
                     <div class="row ml-auto">
-                        <a><i :id="'icon-' + collection + '-' + result._id" class="fas fa-2x" data-toggle="tooltip" title="Add to your basket"></i></a>
+                        <a><i :id="'icon-' + collection + '-' + result._id" class="fas fa-2x" data-toggle="tooltip" title="Add to your basket" @click="handleIconClick"></i></a>
                     </div>
                 </div>
             </div>
@@ -251,7 +258,8 @@ export let searchcomponent = {
             searchTime: 0,
             maxTime: 15000, //milliseconds
             headFilters: ['100','110','111', '130', '150','190','191'],
-            abortController: new AbortController()
+            abortController: new AbortController(),
+            myBasket: {}
         }
     },
     created: async function() {
@@ -413,12 +421,16 @@ export let searchcomponent = {
                             //console.log("this user is not undefined")
                             basket.getBasket(component.api_prefix).then(
                                 myBasket => {
+                                    this.myBasket = myBasket
                                     //console.log(myBasket)
                                     //console.log("got my basket contents")
                                     for (let result of component.results) {
                                         //console.log("processing result")
                                         let myId = `icon-${component.collection}-${result._id}`;
                                         let iconEl = document.getElementById(myId);
+
+                                        let myCheckboxId = `input-${component.collection}-${result._id}`;
+                                        let inputEl = document.getElementById(myCheckboxId);
                                     
                                         if (component.basketContains(myBasket, component.collection, result._id)) {
                                             //iconEl.classList.remove('fa-folder-plus',);
@@ -428,6 +440,7 @@ export let searchcomponent = {
                                         } else {
                                             iconEl.classList.add('fa-folder-plus');
                                             iconEl.title = "Add to basket";
+                                            inputEl.disabled = false
                                         }
 
                                         // checking if the record is locked and displaying a lock if it is.
@@ -442,45 +455,10 @@ export let searchcomponent = {
                                                     // revert link to read only view. 
                                                     // TODO: acquire the lock status earlier 
                                                     document.getElementById("link-" + result._id).href = this.uibase + '/records/' + this.collection + '/' + result._id;
+                                                    inputEl.disabled = true
                                                 }
                                             }
                                         );
-
-                                        iconEl.addEventListener("click", function() {
-                                            if (iconEl.classList.contains("fa-folder-plus")) {
-                                                //console.log("We're trying to create something.")
-                                                basket.getBasket(component.api_prefix)
-                                                iconEl.classList.add("fa-spinner");
-                                                // we can run an add
-                                                basket.createItem(component.api_prefix, 'userprofile/my_profile/basket', component.collection, result._id).then(
-                                                    function() {
-                                                        iconEl.classList.remove("fa-spinner");
-                                                        iconEl.classList.remove("fa-folder-plus");
-                                                        iconEl.classList.add("fa-folder-minus");
-                                                        iconEl.classList.add("text-muted");
-                                                        iconEl.title = "Remove from basket";
-                                                    }
-                                                )
-                                            } else if (iconEl.classList.contains("fa-folder-minus")) {
-                                                //console.log("We're trying to delete something.")
-                                                basket.getBasket(component.api_prefix)
-                                                iconEl.classList.add("fa-spinner");
-                                                // we can run a deletion
-                                                basket.deleteItem(component.api_prefix, 'userprofile/my_profile/basket', myBasket, component.collection, result._id).then(
-                                                    function() {
-                                                        //console.log("But did we do it?")
-                                                        iconEl.classList.remove("fa-spinner");
-                                                        iconEl.classList.remove("fa-folder-minus");
-                                                        iconEl.classList.add("fa-folder-plus");
-                                                        iconEl.classList.remove("text-muted");
-                                                        iconEl.title = "Add to basket";
-                                                    }
-                                                )
-                                            } else if (iconEl.classList.contains("fa-lock")) {
-                                                // TODO: unlock
-
-                                            }
-                                        });
                                     }
                                 }
                             )
@@ -561,6 +539,33 @@ export let searchcomponent = {
                     el.classList.add("fa-folder-plus");
                 })
             }
+        },
+        async handleIconClick(e) {
+            let collection = e.target.id.split("-")[1]
+            let record_id = e.target.id.split("-")[2]
+            e.target.classList.add("fa-spinner");
+            if (e.target.classList.contains("fa-folder-plus")) {
+                await basket.createItem(this.api_prefix, 'userprofile/my_profile/basket', collection, record_id).then( () => {
+                    e.target.classList.remove("fa-spinner");
+                    e.target.classList.remove("fa-folder-plus");
+                    e.target.classList.add("fa-folder-minus");
+                    e.target.classList.add("text-muted");
+                    e.target.title = "Remove from basket";
+                })
+            } else if (e.target.classList.contains("fa-folder-minus")) {
+                await basket.deleteItem(this.api_prefix, 'userprofile/my_profile/basket', this.myBasket, collection, record_id).then( () => {
+                    e.target.classList.remove("fa-spinner");
+                    e.target.classList.remove("fa-folder-minus");
+                    e.target.classList.add("fa-folder-plus");
+                    e.target.classList.remove("text-muted");
+                    e.target.title = "Add to basket";
+                })
+            } else if (e.target.classList.contains("fa-lock")) {
+                // To do: unlock
+            } else {
+                return false
+            }
+            return true
         },
         toggleAdvancedSearch() {
             let el = document.getElementById("advanced-search")
@@ -716,6 +721,31 @@ export let searchcomponent = {
         cancelSearch() {
             this.abortController.abort();
             this.start = this.end = 0;
+        },
+        selectAll()  {
+            for (let inputEl of document.getElementsByTagName("input")) {
+                if (inputEl.type == "checkbox" && !inputEl.disabled) {
+                    inputEl.checked = true
+                }
+            }
+        },
+        selectNone() {
+            for (let inputEl of document.getElementsByTagName("input")) {
+                if (inputEl.type == "checkbox") {
+                    inputEl.checked = false
+                }
+            }
+        },
+        async sendToBasket() {
+            for (let inputEl of document.getElementsByTagName("input")) {
+                if (inputEl.type == "checkbox" && inputEl.checked) {
+                    let collection = inputEl.id.split("-")[1]
+                    let record_id = inputEl.id.split("-")[2]
+                    let iconEl = document.getElementById(`icon-${collection}-${record_id}`)
+                    iconEl.click()
+                    //console.log(collection, record_id)
+                }
+            }
         }
     },
     components: {


### PR DESCRIPTION
Closes #518 

Creates a set of search page controls for selecting and sending records to basket. Limited automatically to the number of records visible on the page. Excludes records that are already in a basket.