### PR TITLE
record object doesn't have parentRecord

### DIFF
--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -1076,7 +1076,7 @@ export class Jmarc {
 	validationWarnings() {
 		let flags = [];
 		//let data = validationData[this.collection];
-		let data = validationData[this.parentRecord.getVirtualCollection()]
+		let data = validationData[this.getVirtualCollection()]
 
 		// check for required fields
 		let required = Object.keys(data).filter(x => data[x].required);


### PR DESCRIPTION
This fixes a slight mistake with the validation handling at the record root level.