### PR TITLE
fix clone record

### DIFF
--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -489,8 +489,8 @@ export let multiplemarcrecordcomponent = {
         },
         cloneRecord(jmarc) {
             let recup = jmarc.clone();
-            console.log(jmarc.div.id)
-            if (jmarc.div.id) {
+            //console.log(jmarc.div.id)
+            if (jmarc.div) {
                 //this.removeRecordFromEditor(jmarc); // div element is stored as a property of the jmarc object
                 this.userClose(jmarc)
             }


### PR DESCRIPTION
There was a call checking for a div.id, but if div was null, it errored. That prevented the from workform record from opening.

Closes #798 