### PR TITLE
Ensure exact phrases appear at top of text lookup results

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -1163,7 +1163,7 @@ class LookupField(Resource):
 
                 # matches start
                 first_word = re.split('\s+', val)[0]
-                conditions_1.append(f'{auth_tag}__{code}:{val} AND {auth_tag}__{code}:{first_word}*')
+                conditions_1.append(f'{auth_tag}__{code}:{val} AND {auth_tag}__{code}:/^{val}/i')
                 # matches anywhere
                 conditions_2.append(f'{auth_tag}__{code}:{val}')
 


### PR DESCRIPTION
Previously only the first word was being looked at. This was causing, for example "United States" to not appear in the top 25 results when looking up values for field 710.

closes #804 