### PR TITLE
Handle error preventing save of records with old auth ctrl data in database ($9)

### DIFF
--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -840,7 +840,9 @@ export class Jmarc {
 						let newSub = newField.getSubfield(subfield.code, seen[subfield.code]) || newField.createSubfield(subfield.code);
 						newSub._seen = true; // temp flag used for differentiating previous state
 						newSub.value = subfield.value;
-                        newSub.xref = subfield.xref;
+                        if (tag in authMap[this.collection] && subfield.code in authMap[this.collection][tag]) {
+							newSub.xref = subfield.xref
+						}
 						if (! seen[subfield.code]) seen[subfield.code] = 0;
 						seen[subfield.code]++;
 					}


### PR DESCRIPTION
xref data is now ignored on record parse if the field is not configured as auth controlled