### PR TITLE
Update bibs and votes validations

### DIFF
--- a/dlx_rest/static/js/validation.js
+++ b/dlx_rest/static/js/validation.js
@@ -1154,7 +1154,7 @@ export const validationData = {
             "name": "Added entry - corporate name",
             "required": false,
             "repeatable": true,
-            "validIndicators1": ["_","0","2"],
+            "validIndicators1": ["_","0","1","2"],
             "validIndicators2": [],
             "requiredSubfields": [],
             "validSubfields": ["a","9"],

--- a/dlx_rest/static/js/validation.js
+++ b/dlx_rest/static/js/validation.js
@@ -2759,7 +2759,7 @@ export const validationData = {
             "validIndicators1": [],
             "validIndicators2": [],
             "requiredSubfields": [],
-            "validSubfields": ["b"],
+            "validSubfields": ["a","b"],
             "defaultSubfields": ["b"],
             "validStrings": {
                 "b": ["B23"]
@@ -2815,7 +2815,7 @@ export const validationData = {
             "validIndicators1": [],
             "validIndicators2": [],
             "requiredSubfields": [],
-            "validSubfields": ["a","b","c","z"],
+            "validSubfields": ["a","b","c","q","r","z"],
             "defaultSubfields": ["a","b","c"]   // Values copied over from 191 of the linked record?
         },
         "793": {
@@ -2854,7 +2854,7 @@ export const validationData = {
         },
         "967": {
             "name": "Voting information",   // divided into three fields (967, 968, 969) because Horizon has a limit on repeated tags
-            "required": true,               // Only one of these should be required, though, not all three
+            "required": false,               // Only one of these should be required, though, not all three
             "repeatable": true,
             "validIndicators1": [],
             "validIndicators2": [],
@@ -2864,7 +2864,7 @@ export const validationData = {
         },
         "968": {
             "name": "Voting information",   // divided into three fields (967, 968, 969) because Horizon has a limit on repeated tags
-            "required": true,               // Only one of these should be required, though, not all three
+            "required": false,               // Only one of these should be required, though, not all three
             "repeatable": true,
             "validIndicators1": [],
             "validIndicators2": [],
@@ -2874,7 +2874,7 @@ export const validationData = {
         },
         "969": {
             "name": "Voting information",   // divided into three fields (967, 968, 969) because Horizon has a limit on repeated tags
-            "required": true,               // Only one of these should be required, though, not all three
+            "required": false,               // Only one of these should be required, though, not all three
             "repeatable": true,
             "validIndicators1": [],
             "validIndicators2": [],
@@ -2919,7 +2919,7 @@ export const validationData = {
         },
         "996": {
             "name": "Vote note",
-            "required": true,
+            "required": false,
             "repeatable": false,
             "validIndicators1": [],
             "validIndicators2": [],
@@ -2938,7 +2938,7 @@ export const validationData = {
             "validSubfields": ["a","b","c"],
             "defaultSubfields": ["a","b","c"],
             "validStrings": {
-                "c": ["s","t"]
+                "c": ["v","u","t"]
             }
         },
     }


### PR DESCRIPTION
Closes #805 
Closes #806 except that dates can still be entered as six digits (e.g., 202212 will save as 2022-12)