### PR TITLE
add download attribute to download file link

### DIFF
--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -2071,6 +2071,7 @@ export let multiplemarcrecordcomponent = {
                     let fileDownload = document.createElement("a");
                     fileDownload.href = `${f['url']}?action=download`;
                     fileDownload.title = "Download";
+                    fileDownload.setAttribute("download","true")
                     let downloadIcon = document.createElement("i");
                     downloadIcon.className = "fas fa-cloud-download-alt text-dark";
                     fileDownload.appendChild(downloadIcon);


### PR DESCRIPTION
This is a small change so file download clicks don't trigger the beforeunload window event.

Closes #843 