### PR TITLE
update wording on unsaved close

### DIFF
--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -126,16 +126,16 @@ export let multiplemarcrecordcomponent = {
                     <div class="modal-footer">
                         <slot name="footer">
                         <button type="button" data-dismiss="modal" class="btn btn-primary" 
-                            @click="closeModalSave();saveRecord(selectedJmarc,false);removeRecordFromEditor(selectedJmarc)"> Save
+                            @click="closeModalSave();saveRecord(selectedJmarc,false);removeRecordFromEditor(selectedJmarc)"> Save and close
                         </button>
                         <button type="button" data-dismiss="modal" class="btn btn-primary" 
-                            @click="closeModalSave();saveRecord(selectedJmarc,false);removeRecordFromEditor(selectedJmarc);$root.$refs.basketcomponent.removeRecordFromList(selectedJmarc.collection, selectedJmarc.recordId)"> Save and release
+                            @click="closeModalSave();saveRecord(selectedJmarc,false);removeRecordFromEditor(selectedJmarc);$root.$refs.basketcomponent.removeRecordFromList(selectedJmarc.collection, selectedJmarc.recordId)"> Save and remove from basket
                         </button>
                         <button type="button" data-dismiss="modal" class="btn btn-primary" 
-                            @click="closeModalSave();removeRecordFromEditor(selectedJmarc,false,true);"> Close and discard
+                            @click="closeModalSave();removeRecordFromEditor(selectedJmarc,false,true);"> Close without saving
                         </button>
                         <button type="button" data-dismiss="modal" class="btn btn-primary" 
-                            @click="closeModalSave()"> Cancel
+                            @click="closeModalSave()"> Cancel<br><br>
                         </button>
                         </slot>
                     </div>


### PR DESCRIPTION
Closes #731 

To test: Open a record in the record editor. Make a change to any field. Without saving, try to close the record. Note that the wording now reads: 

Button 1: Save and close
Button 2: Save and remove from basket
Button 3: Close without saving
Button 4: Cancel