### PR TITLE
use partial lookup for 791

### DIFF
--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -319,7 +319,7 @@ export class DataField {
 		let url = Jmarc.apiUrl + `marc/${collection}/lookup/${this.tag}?${lookupString}`;
 
 		// determine the lookup type
-		if (["191", "991"].includes(this.tag)) {
+		if (["191", "791", "991"].includes(this.tag)) {
 			url += '&type=partial'
 		} else {
 			url += '&type=text'


### PR DESCRIPTION
closes #881 

Use partial string auth lookup for 791. 

Test: Users can now search for the string "A" in 791$b