### PR TITLE
don't exlcude records without sort field from search results

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -257,7 +257,8 @@ class RecordsList(Resource):
             sort = [(sort_by, DESC)] if (args['direction'] or '').lower() == 'desc' else [(sort_by, ASC)]
             # only include results with the sorted field. otherwise, records with the field missing will be the first results
             # TODO review
-            query.add_condition(Raw({sort_by: {'$exists': True}}))
+            #query.add_condition(Raw({sort_by: {'$exists': True}}))
+            pass
         else:
             sort = None
 


### PR DESCRIPTION
closes #852 

Records not containing the sort by field were being excluded from search results. They are now included.