### PR TITLE
adjust auth text lookup query

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -1181,8 +1181,7 @@ class LookupField(Resource):
                 # exact match
                 conditions_1.append(f'{auth_tag}__{code}:{val} AND {auth_tag}__{code}:\'{val}\'')
                 # matches start
-
-                conditions_2.append(f'{auth_tag}__{code}:{val} AND {auth_tag}__{code}:/^{val}/i')
+                conditions_2.append(f'{auth_tag}__{code}:/^{val}/i')
                 # free text
                 conditions_3.append(f'{auth_tag}__{code}:{val}')
 


### PR DESCRIPTION
closes #837 

Fix partial string match at beginning of the lookup string in free text auth lookup. Partial strings at the beginning of the string match, but at this time punctuation must match as well. i.e. typing "ahmed, raf" in 700$a yields "Ahmed, Rafeeuddin". "ahmed raf" without comma does not yield any results, but "ahmed rafeeuddin" does.