### PR TITLE
Search/sort updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cfn-flip==1.3.0
 charset-normalizer==2.0.12
 click==8.1.2
 cryptography==36.0.2
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@e6b92478544084779e48896dd7bc7b947c52a206
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@c428ca5877fb4bf0a09e65f8f6546ee34b6384f4
 dnspython==2.2.1
 email-validator==1.1.3
 Flask==2.1.1


### PR DESCRIPTION
closes #478, closes #651, closes #735, closes #877 

* Most diacritics are now ignored in text search, browse and sorting. Caveat: Some characters are still not recognized by MDB at this time as "equivalent" that we would expect. Examples include "Ø" : "O" and "İ" : "I". This still may improve in the future with database upgrades and/or workarounds.
* All sorting is now numeric. The DB indexes for all fields are now by default case and diacritic insensitive, as well as numeric.
* Search results sort by symbol now works the same as all other fields. Previously, there was a workaround in place due to discrepancies in the indexes which have now been resolved.
  