### PR TITLE
Flask timeout

### DIFF
--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -5,7 +5,7 @@ import re
 import dlx
 from flask import url_for, Flask, abort, g, jsonify, request, redirect, render_template, flash, session
 from flask_login import current_user, login_user, login_required, logout_user
-from datetime import datetime
+from datetime import datetime, timedelta
 from urllib.parse import urlparse, parse_qs
 import json, requests
 from dlx.file import File, Identifier, S3, FileExists, FileExistsLanguageConflict, FileExistsIdentifierConflict
@@ -19,6 +19,15 @@ from dlx_rest.models import RecordView, User, SyncLog, Permission, Role, require
 from dlx_rest.forms import LoginForm, RegisterForm, CreateUserForm, UpdateUserForm, CreateRoleForm, UpdateRoleForm
 from dlx_rest.utils import is_safe_url
 
+# This function sets an expiration/timeout for idle sessions.
+# We can configure this to anything we like, but 15 minutes is 
+# typical, and mentioned under OICT security controls.
+# If we implement this, we should alert the user with enough 
+# time to respond accordingly.
+@app.before_request
+def make_sesion_permanent():
+    session.permanent = True
+    app.permanent_session_lifetime = timedelta(minutes=15)
 
 # Main app routes
 @app.route('/')

--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -29,6 +29,10 @@ def make_sesion_permanent():
     session.permanent = True
     app.permanent_session_lifetime = timedelta(minutes=15)
 
+    # Special case for testing, so we can test this without waiting too long
+    if Config.TESTING:
+        app.permanent_session_lifetime = timedelta(minutes=1)
+
 # Main app routes
 @app.route('/')
 def index():
@@ -426,6 +430,7 @@ def get_records_list(coll):
 
 @app.route('/records/<coll>/search')
 def search_records(coll):
+    #print(session.get('_id')) # Returns id if authenticated, or None if not.
     api_prefix = url_for('doc', _external=True)
     limit = request.args.get('limit', 25)
     start = request.args.get('start', 1)

--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -31,7 +31,7 @@ def make_sesion_permanent():
 
     # Special case for testing, so we can test this without waiting too long
     if Config.TESTING:
-        app.permanent_session_lifetime = timedelta(minutes=1)
+        app.permanent_session_lifetime = timedelta(seconds=5)
 
 # Main app routes
 @app.route('/')

--- a/dlx_rest/tests/conftest.py
+++ b/dlx_rest/tests/conftest.py
@@ -107,10 +107,7 @@ def default_users():
 @pytest.fixture(scope='module')
 def client():
     from dlx_rest.app import app
-    
     app.TESTING = True
-    #app.config.update(SERVER_NAME='0.0.0.0:80')
-    
     return app.test_client()
 
 @pytest.fixture(scope='module')

--- a/dlx_rest/tests/test_app.py
+++ b/dlx_rest/tests/test_app.py
@@ -24,7 +24,6 @@ def login(client, username, password):
     return response
 
 def logout(client):
-
     response = client.get('/logout', follow_redirects=True)
     return response
 
@@ -56,18 +55,27 @@ def test_logout(client):
     assert b'Logged out successfully' in rv.data
 
 def test_session_timeout(client, default_users):
-    # A new session should be completely empty.
+    # The timeout is lowered to 5 seconds for testing, so we'll sleep just
+    # long enough to ensure the session is timed out.
+    # Also, it turns out that the session from above was still active...
+    time.sleep(7)
     with client.session_transaction() as session:
         response = client.get('/records/bibs/search')
-        print(session)
+        #print(session)
         assert session.get('_fresh') == None
+
+    # A new session should be completely empty.
+    #with client.session_transaction() as session:
+    #    response = client.get('/records/bibs/search')
+    #    print(session)
+    #    assert session.get('_fresh') == None
         
     # While an existing session should have some data in it.
     with client.session_transaction() as session:
         user = default_users['admin']
         rv = login(client, user['email'], user['password'])
         response = client.get('/records/bibs/search')
-        print(session)
+        #print(session)
         assert session.get('_fresh') == False
 
     # Sleep a short amount of time, then try again to make sure the session
@@ -75,16 +83,10 @@ def test_session_timeout(client, default_users):
     time.sleep(2)
     with client.session_transaction() as session:
         response = client.get('/records/bibs/search')
-        print(session)
+        #print(session)
         assert session.get('_fresh') == False
     
-    # The timeout is lowered to 5 seconds for testing, so we'll sleep just
-    # long enough to ensure the session is timed out.
-    time.sleep(7)
-    with client.session_transaction() as session:
-        response = client.get('/records/bibs/search')
-        print(session)
-        assert session.get('_fresh') == None
+    
 
 # Administration
 # All of these should work only if authenticated.

--- a/dlx_rest/tests/test_app.py
+++ b/dlx_rest/tests/test_app.py
@@ -2,6 +2,7 @@ import os
 os.environ['DLX_REST_TESTING'] = 'True'
 import pytest 
 import json, re
+#from flask import session
 from dlx_rest.config import Config
 from dlx_rest.forms import LoginForm
 from flask_login import LoginManager, current_user, login_user, login_required, logout_user
@@ -50,6 +51,15 @@ def test_logout(client):
     rv = logout(client)
     assert rv.status_code == 200
     assert b'Logged out successfully' in rv.data
+
+def test_session_timeout(client, default_users):
+    with client.session_transaction() as session:
+        #response = client.get('/records/bibs/search')
+        assert session.get('_id') == None
+        user = default_users['admin']
+        rv = login(client, user['email'], user['password'])
+        print(session.get('_id'))
+        assert session.get('_id') != None
 
 # Administration
 # All of these should work only if authenticated.


### PR DESCRIPTION
Sets a 15 minute session timeout on the application. Authenticated users who are idle for 15 minutes will have to login again. This value is configurable in routes.py, but 15 minutes is the standard in OICT's security controls.

Also provides tests for this functionality.