### PR TITLE
Bugfix in query parser properly parses "AND", "OR", "NOT" inside quotes.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ charset-normalizer==2.0.12
 click==8.1.2
 cryptography==36.0.2
 dlx @ git+https://github.com/dag-hammarskjold-library/dlx@03abffcc886fbf062cc116176b57173e082206c7
-dnspython==2.2.1
+dnspython==2.3.0
 email-validator==1.1.3
 Flask==2.1.1
 Flask-Cors==3.0.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cfn-flip==1.3.0
 charset-normalizer==2.0.12
 click==8.1.2
 cryptography==36.0.2
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@49345b1652cdca4556b28348dd939e2ca8c5cadf
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@03abffcc886fbf062cc116176b57173e082206c7
 dnspython==2.2.1
 email-validator==1.1.3
 Flask==2.1.1


### PR DESCRIPTION
Update dlx. Bugfix in query parser properly parses "AND", "OR", "NOT" inside quotes. 

To test: search `agenda:'S/77 [301] SPECIAL COURT FOR SIERRA LEONE'` (requires dlx update in local environment)