### PR TITLE
Auth merge bugfix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cfn-flip==1.3.0
 charset-normalizer==2.0.12
 click==8.1.2
 cryptography==36.0.2
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@2274ba1267eb13d3acb8f47448957b22b39244b3
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@29a594d03ee411e1a1af325504eb5abb08cbcb7a
 dnspython==2.3.0
 email-validator==1.1.3
 Flask==2.1.1


### PR DESCRIPTION
Auth records with different subfields in the heading field were throwing an exception on merge and preventing merge.

Requires dlx update https://github.com/dag-hammarskjold-library/dlx/commit/29a594d03ee411e1a1af325504eb5abb08cbcb7a

closes #1035 