### PR TITLE
use exact regex match to detect auth dupe heading; update dlx

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -383,12 +383,16 @@ class RecordsListCount(Resource):
         
         meta = {'name': 'api_records_list_count', 'returns': URL('api_schema', schema_name='api.count').to_str()}
         
-        data = cls().handle.count_documents(
-            query.compile(),
-            # collation is not implemented in mongomock
-            collation=Collation(locale='en', strength=1, numericOrdering=True) if Config.TESTING == False else None,
-            maxTimeMS=Config.MAX_QUERY_TIME) if query else cls().handle.estimated_document_count()
-        
+        if query:
+            data = cls().handle.count_documents(
+                query.compile(),
+                # collation is not implemented in mongomock
+                collation=Collation(locale='en', strength=1, numericOrdering=True) if Config.TESTING == False else None,
+                maxTimeMS=Config.MAX_QUERY_TIME
+            )
+        else:
+            data = cls().handle.estimated_document_count()
+
         return ApiResponse(links=links, meta=meta, data=data).jsonify()
 
 # Records list browse

--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -1099,9 +1099,11 @@ export class Jmarc {
 
 		if (! headingField) return
 
+		let regex = new RegExp()
+
 		let searchStr = 
     	    headingField.subfields
-    	    .map(x => `${headingField.tag}__${x.code}:'${x.value}'`)
+    	    .map(x => `${headingField.tag}__${x.code}:/^${x.value}$/`) // regex ensures exact match
     	    .join(" AND ");
 
     	let url = Jmarc.apiUrl + "/marc/auths/records/count?search=" + searchStr;

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cfn-flip==1.3.0
 charset-normalizer==2.0.12
 click==8.1.2
 cryptography==39.0.1
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@29a594d03ee411e1a1af325504eb5abb08cbcb7a
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@f62080d28a74e4f45c8765da1564868415329936
 dnspython==2.3.0
 email-validator==1.1.3
 Flask==2.1.1


### PR DESCRIPTION
Due to loosened search collation, auth heading detection was not precise enough. Here we use exact regex match to ensure case, diactritic and punctuation sensitivity.

Requires dlx update (bugfix in regex search https://github.com/dag-hammarskjold-library/dlx/pull/219)