### PR TITLE
Search result record previews

### DIFF
--- a/dlx_rest/static/css/search.css
+++ b/dlx_rest/static/css/search.css
@@ -2,3 +2,26 @@
 a.result-link {
     color: #0000EE
 }
+
+div.record-preview {
+    position: absolute;
+    display: block;
+    z-index: 1;
+    background: rgba(255, 255, 255, 0.95);
+    border: 1px solid black;
+    box-shadow: -1px 2px 2px gray;
+}
+
+span.record-preview-id {
+    font-weight: bold;
+    font-style: italic;
+}
+
+span.preview-text {
+    font-size: 13px;
+}
+
+/**/
+div.hidden {
+    display: none;
+}

--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -913,7 +913,7 @@ export class Jmarc {
 	}
 
 	toStr() {
-		return this.fields.filter(x => ! x.tag.match(/^00/)).map(x => `${x.tag} ${x.toStr()}`).join("\n")
+		return this.fields.filter(x => ! x.tag.match(/^00/)).map(x => `: ${x.tag} ${x.toStr()}`).join("\n")
 	}
 	
 	async history() {


### PR DESCRIPTION
Adds a clickable icon next to each search result that displays a preview of the record, without opening the record editor