### PR TITLE
include tlsCAFile option in mongoengine connect

### DIFF
--- a/dlx_rest/app.py
+++ b/dlx_rest/app.py
@@ -7,6 +7,7 @@ from flask_cors import CORS
 from dlx import DB
 from dlx.marc import BibSet, Bib, AuthSet, Auth
 from dlx_rest.config import Config
+import certifi
 
 #DB.connect(Config.connect_string)
 
@@ -18,7 +19,7 @@ login_manager.init_app(app)
 login_manager.login_view = "login"
 login_manager.login_message =""
 
-connect(host=Config.connect_string,db=Config.dbname)
+connect(host=Config.connect_string,db=Config.dbname, tlsCAFile=certifi.where())
 DB.connect(Config.connect_string, database=Config.dbname)
 
 try:


### PR DESCRIPTION
Closes #1080

Adds the tlsCAFile option to the mongoengine connect() call in app.py. Note this was already included in dlx. Its absence in dlx-rest means the switch to Atlas should not have worked, but it was in some environments.