### PR TITLE
add login_required to /help route

### DIFF
--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -48,6 +48,7 @@ def editor():
     return render_template('new_ui.html', title="Editor", prefix=this_prefix, records=records, workform=workform, fromWorkform=fromWorkform, vcoll="editor")
 
 @app.route('/help')
+@login_required
 def help():
     return render_template('help.html', vcoll="help", title="Help")
 


### PR DESCRIPTION
Closes #901

Makes the /help route require authentication.

To test: Prior to logging in, navigate to the Help link in the site header. Enter credentials and note that the help page loads.