### PR TITLE
Basket-based batch update

### DIFF
--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -1075,6 +1075,7 @@ export class Jmarc {
     }
 
 	validationWarnings() {
+		// record level validations
 		let flags = [];
 		//let data = validationData[this.collection];
 		let data = validationData[this.getVirtualCollection()]
@@ -1090,6 +1091,21 @@ export class Jmarc {
 		});
 
 		return flags
+	}
+
+	allValidationWarnings() {
+		// returns validation flags at all levels: record, field, subfield
+		let flags = this.validationWarnings();
+
+		this.getDataFields().forEach(field => {
+			flags.push(field.validationWarnings().flat());
+
+			field.subfields.forEach(subfield => {
+				flags.push(subfield.validationWarnings().flat())
+			})
+		});
+
+		return flags.flat()
 	}
 
 	async authHeadingInUse() {

--- a/dlx_rest/static/js/modals/batch_edit.js
+++ b/dlx_rest/static/js/modals/batch_edit.js
@@ -195,13 +195,10 @@ export let batcheditmodal = {
                     let subfields = []
                     for (let subfield of field.subfields) {
                         let newSubfield = newField.createSubfield(subfield.code)
-                        if (subfield.xref !== undefined) {
-                            newSubfield.xref = subfield.xref
-                            subfields.push({"code": subfield.code, xref: subfield.xref})
-                        } else {
-                            newSubfield.value = subfield.value
-                            subfields.push({"code": subfield.code, "value": subfield.value})
-                        }
+                        newSubfield.code = subfield.code
+                        newSubfield.value = subfield.value
+                        newSubfield.xref = subfield.xref
+                        subfields.push(newSubfield)
                     }
                     result["fields"].push({"field": field.tag, "subfields": subfields, "action": "added"})
                 }

--- a/dlx_rest/static/js/modals/batch_edit.js
+++ b/dlx_rest/static/js/modals/batch_edit.js
@@ -11,13 +11,13 @@ export let batcheditmodal = {
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="batchActionsModalTitle">Batch Actions</h5>
+                    <h5 class="modal-title" id="batchActionsModalTitle"><i class="fas fa-tasks pr-2" />Basket Update</h5>
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                     </button>
                 </div>
                 <div class="modal-body">
-                    <h6>Select your action</h6>
+                    <h6>Select Action</h6>
                     <div class="form-check form-check-inline">
                         <input class="form-check-input" type="radio" id="add" name="actions" value="add" checked>
                         <label class="form-check-label" for="add">Add</label>
@@ -26,15 +26,32 @@ export let batcheditmodal = {
                         <input class="form-check-input" type="radio" id="delete" name="actions" value="delete">
                         <label class="form-check-label" for="delete">Delete</label>
                     </div>
-                    <div class="row" v-if="selectedFields.length == 0">You have no selected fields</div>
-                    <h6 class="pt-2" v-else>These fields:</h6>
-                    <div class="row"><span class="mx-2" v-for="field in selectedFields" :key="field.tag">{{field.tag}} {{field.toStr()}}</span></div>
-                    <div class="row py-3">
-                        <h6>To/From these records</h6>
-                        <div class="card" v-for="item in basketItems" :key="item._id">{{item.title}}</div></div>
+                    <div class="row pt-1" v-if="selectedFields.length == 0">
+                        <div class="col">You have no selected fields</div>
+                    </div>
+                    <h6 class="pt-1" v-else>These fields:</h6>
+                    <div class="row">
+                        <div class="col"><span class="mx-2" v-for="field in selectedFields" :key="field.tag">{{field.tag}} {{field.toStr()}}</span></div>
+                    </div>
+                    <div class="row pt-2">
+                        <div class="col">
+                            <h6>Select records from the basket:</h6>
+                            <div class="row">
+                                <div class="col">
+                                Select <a href="#" @click="select" id="all">All</a> or <a href="#" @click="select" id="none">None</a>
+                                </div>
+                            </div>
+                            <div class="row px-2" v-for="item in basketItems" :key="item._id">
+                                <div class="form-check form-check-inline">
+                                    <input class="form-check-input record-selector" type="checkbox" :id="item._id" :data-collection="item.collection" @click="toggleSelect" >
+                                    <label class="form-check-label" :for="item._id">{{item.title}} ({{item.collection}}/{{item._id}})</label>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-primary" v-if="selectedFields.length > 0">Apply</button>
+                    <button type="button" class="btn btn-primary" v-if="selectedFields.length > 0" @click="applySelection" id="batchUpdateSubmit" disabled>Apply</button>
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                 </div>
                 </div>
@@ -44,30 +61,77 @@ export let batcheditmodal = {
         return {
             basketItems: [],
             selectedFields: [],
-            actions: ["Add to All", "Delete from All"],
-            selected: "Add to All"
-            //show: false
+            selectedRecords: []        
         }
     },
+    emits: ['update-records'],
     created: function () {
         this.basketItems = this.$root.$refs.basketcomponent.basketItems
-        console.log(this.basketItems)
+    },
+    watch: {
+        selectedRecords() {
+            let button = document.getElementById("batchUpdateSubmit")
+            button.disabled = this.selectedRecords.length == 0
+        }
     },
     methods: {
         updateSelectedFields(selectedFields) {
             this.selectedFields = selectedFields
-            console.log(this.selectedFields)
         },
-        handleClick() {
+        toggleSelect(event) {
+            let record = [event.target.dataset.collection, event.target.id].join("/")
+            if (event.target.checked) {
+                this.selectedRecords.push(record)
+            } else {
+                this.selectedRecords.splice(this.selectedRecords.indexOf(record), 1)
+            }
+        },
+        select(event) {
+            event.preventDefault()
+            let which = event.target.id
+            let checkboxes = document.querySelectorAll('input.record-selector[type="checkbox"]')
+            for (let checkbox of checkboxes) {
+                let record = [checkbox.dataset.collection, checkbox.id].join("/")
+                if (which == "all") {
+                    if (checkbox.checked == false) {
+                        checkbox.checked = true
+                        this.selectedRecords.push(record)
+                    }
+                } else if (which == "none") {
+                    checkbox.checked = checkbox.checked == false ? false : false
+                    this.selectedRecords.splice(this.selectedRecords.indexOf(record), 1)
+                }
+            }
+        },
+        applySelection() {
             // Find which radio button is selected and call the corresponding function when the Update Records button is clicked
+            let selected = document.querySelector('input[name="actions"]:checked').value
+            console.log(selected)
+            if (this.selectedRecords.length > 0) {
+                if (selected == "add") {
+                    this.addToAll(this.selectedFields, this.selectedRecords)
+                } else if (selected == "delete") {
+                    this.deleteFromAll(this.selectedFields, this.selectedRecords)
+                }
+            } else {
+                alert("Please select at least one record")
+            }
         },
         addToAll(selectedFields, selectedRecords) {
             // Add the selected fields to the selected records in the basket
-            //basket.addToAll(selectedFields)
+            // We need jmarc for each of the selected records, which we will update
+            // by adding the selected fields.
+            console.log("Adding to all")
+            console.log(selectedFields, selectedRecords)
+            // If true
+            this.$emit('update-records', { "message": "Field(s) added", "count": this.selectedRecords.length } )
         },
         deleteFromAll(selectedFields, selectedRecords) {
             // Delete the selected fields from the selected records in the basket
-            //basket.deleteFromAll(selectedFields)
+            // We need jmarc for each of the selected records, which we will update
+            // by deleting the selected fields.
+            console.log("Deleting from all")
+            this.$emit('update-records', { "message": "Field(s) deleted", "count": this.selectedRecords.length } )
         }
     }
 }

--- a/dlx_rest/static/js/modals/batch_edit.js
+++ b/dlx_rest/static/js/modals/batch_edit.js
@@ -31,7 +31,7 @@ export let batcheditmodal = {
                     </div>
                     <h6 class="pt-1" v-else>These fields:</h6>
                     <div class="row">
-                        <div class="col"><span class="mx-2" v-for="field in selectedFields" :key="field.tag">{{field.tag}} {{field.toStr()}}</span></div>
+                        <div class="col"><p v-for="field in selectedFields" :key="field.tag">{{field.tag}} {{field.toStr()}}</p></div>
                     </div>
                     <div class="row pt-2">
                         <div class="col">
@@ -41,12 +41,16 @@ export let batcheditmodal = {
                                 Select <a href="#" @click="select" id="all">All</a> or <a href="#" @click="select" id="none">None</a>
                                 </div>
                             </div>
-                            <div class="row px-2" v-for="item in basketItems" :key="item._id">
-                                <div class="form-check form-check-inline">
-                                    <input class="form-check-input record-selector" type="checkbox" :id="item._id" :data-collection="item.collection" @click="toggleSelect" >
-                                    <label class="form-check-label" :for="item._id">{{item.title}} ({{item.collection}}/{{item._id}})</label>
-                                </div>
-                            </div>
+                            <table class="table table-striped table-hover">
+                                <tbody>
+                                <tr v-for="item in basketItems" :key="item._id">
+                                    <td>
+                                        <input v-if="!matchesReferrer(item.collection, item._id)" class="field-checkbox record-selector" type="checkbox" :id="item._id" :data-collection="item.collection" @click="toggleSelect">
+                                    </td>
+                                    <td><label class="form-check-label" :for="item._id">{{item.title}} ({{item.collection}}/{{item._id}})</label></td>
+                                </tr>
+                                </tbody>
+                            </table>
                         </div>
                     </div>
                 </div>
@@ -59,10 +63,14 @@ export let batcheditmodal = {
         </div>`,
     data: function () {
         return {
+            referringRecord: null,
             basketItems: [],
             selectedFields: [],
-            selectedRecords: []        
+            selectedRecords: [],
         }
+    },
+    computed: {
+        
     },
     emits: ['update-records'],
     created: function () {
@@ -71,12 +79,22 @@ export let batcheditmodal = {
     watch: {
         selectedRecords() {
             let button = document.getElementById("batchUpdateSubmit")
-            button.disabled = this.selectedRecords.length == 0
+            if (button) {
+                button.disabled = this.selectedRecords.length == 0
+            }
         }
     },
     methods: {
         updateSelectedFields(selectedFields) {
             this.selectedFields = selectedFields
+        },
+        setReferringRecord(collection, recordId) {
+            this.referringRecord = `${collection}/${recordId}`
+            console.log(this.referringRecord)
+        },
+        matchesReferrer: function (collection, recordId) {
+            let testRecord = [collection, recordId].join("/")
+            return testRecord === this.referringRecord
         },
         toggleSelect(event) {
             let record = [event.target.dataset.collection, event.target.id].join("/")

--- a/dlx_rest/static/js/modals/batch_edit.js
+++ b/dlx_rest/static/js/modals/batch_edit.js
@@ -1,0 +1,29 @@
+import { basket } from '../api/basket'
+import { Jmarc } from '../jmarc.mjs'
+
+/* 
+Modal for batch editing records using basket functionality
+*/
+
+export let batchEdit = {
+    template: `<div class="batch-edit">
+
+    </div>`,
+    data: function () {
+        return {}
+    },
+    created: function () {},
+    methods: {
+        handleClick() {
+            // Find which radio button is selected and call the corresponding function when the Update Records button is clicked
+        },
+        addToAll(selectedFields, selectedRecords) {
+            // Add the selected fields to the selected records in the basket
+            //basket.addToAll(selectedFields)
+        },
+        deleteFromAll(selectedFields, selectedRecords) {
+            // Delete the selected fields from the selected records in the basket
+            //basket.deleteFromAll(selectedFields)
+        }
+    }
+}

--- a/dlx_rest/static/js/modals/batch_edit.js
+++ b/dlx_rest/static/js/modals/batch_edit.js
@@ -119,6 +119,13 @@ export let batcheditmodal = {
         }
     },
     methods: {
+        reinitialize() {
+            this.includeReferrer = false
+            this.confirm = false
+            this.results = []
+            this.selectedRecords = []
+            
+        },
         matchesReferrer: function (collection, recordId) {
             let testRecord = [collection, recordId].join("/")
             return testRecord === this.referringRecord

--- a/dlx_rest/static/js/modals/batch_edit.js
+++ b/dlx_rest/static/js/modals/batch_edit.js
@@ -6,13 +6,8 @@ Modal for batch editing records using basket functionality
 */
 
 export let batcheditmodal = {
-    //template: `<div class="modal fade" id="batchActions" tabindex="-1" role="dialog" aria-labelledby="batchActionsModalTitle" aria-hidden="true">
-    //<div><p v-for="field in selectedFields" :key="field.id">{{field.name}}</p></div>
-    //<div><p v-for="item in basketItems" :key="item.id">{{item.name}}</p></div>
-    //</div>`,
     template: `
-    <div v-if="show">
-        <div class="modal fade" id="batchActions" tabindex="-1" role="dialog" aria-labelledby="batchActionsModalTitle" aria-hidden="true">
+        <div class="modal fade" id="batchActions" role="dialog" aria-labelledby="batchActionsModalTitle" aria-hidden="true">
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                 <div class="modal-header">
@@ -22,29 +17,46 @@ export let batcheditmodal = {
                     </button>
                 </div>
                 <div class="modal-body">
-                    <div><p v-for="field in selectedFields" :key="field.id">{{field.name}}</p></div>
-                    <div><p v-for="item in basketItems" :key="item.id">{{item.name}}</p></div>
+                    <h6>Select your action</h6>
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="radio" id="add" name="actions" value="add" checked>
+                        <label class="form-check-label" for="add">Add</label>
+                    </div>
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="radio" id="delete" name="actions" value="delete">
+                        <label class="form-check-label" for="delete">Delete</label>
+                    </div>
+                    <div class="row" v-if="selectedFields.length == 0">You have no selected fields</div>
+                    <h6 class="pt-2" v-else>These fields:</h6>
+                    <div class="row"><span class="mx-2" v-for="field in selectedFields" :key="field.tag">{{field.tag}} {{field.toStr()}}</span></div>
+                    <div class="row py-3">
+                        <h6>To/From these records</h6>
+                        <div class="card" v-for="item in basketItems" :key="item._id">{{item.title}}</div></div>
                 </div>
                 <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" v-if="selectedFields.length > 0">Apply</button>
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                 </div>
                 </div>
             </div>
-        </div>
-    </div>`,
+        </div>`,
     data: function () {
         return {
             basketItems: [],
             selectedFields: [],
-            show: false
+            actions: ["Add to All", "Delete from All"],
+            selected: "Add to All"
+            //show: false
         }
     },
+    created: function () {
+        this.basketItems = this.$root.$refs.basketcomponent.basketItems
+        console.log(this.basketItems)
+    },
     methods: {
-        showModal: function() {
-            console.log("Show?", this.show)
-            this.show = true
-            console.log("Show?", this.show)
-            return true
+        updateSelectedFields(selectedFields) {
+            this.selectedFields = selectedFields
+            console.log(this.selectedFields)
         },
         handleClick() {
             // Find which radio button is selected and call the corresponding function when the Update Records button is clicked

--- a/dlx_rest/static/js/modals/batch_edit.js
+++ b/dlx_rest/static/js/modals/batch_edit.js
@@ -213,10 +213,20 @@ export let batcheditmodal = {
                 let validationFlags = jmarc.allValidationWarnings() // new method added to Jmarc to get flags at all levels (record, field, subfield)
                 //console.log(validationFlags)
                 if (validationFlags.length > 0) {
-                    // We have an error
-                    result["invalid"] = true
-                    result["message"] = validationFlags.map(x => x.message)
-                    errors += 1
+                    // Check if we can save on invalid; see record.js L#443 for comparison
+                    if (jmarc.getField("998")) {
+                        // proceed
+                        jmarc.put().catch(err => {
+                            throw err
+                            errors += 1
+                        })
+                    } else {
+                        // We have an error
+                        result["invalid"] = true
+                        result["message"] = validationFlags.map(x => x.message)
+                        errors += 1
+                    }
+                    
                 } else {
                     // save record if no warnings
                     // do we want to do this here, or do we only want to make any updates if all records are valid?
@@ -263,10 +273,20 @@ export let batcheditmodal = {
                 let validationFlags = jmarc.allValidationWarnings() // new method added to Jmarc to get flags at all levels (record, field, subfield)
                 //console.log(validationFlags)
                 if (validationFlags.length > 0) {
-                    // We have an error
-                    result["invalid"] = true
-                    result["message"] = validationFlags.map(x => x.message)
-                    errors += 1
+                    // Check if we can save on invalid; see record.js L#443 for comparison
+                    if (jmarc.getField("998")) {
+                        // proceed
+                        jmarc.put().catch(err => {
+                            throw err
+                            errors += 1
+                        })
+                    } else {
+                        // We have an error
+                        result["invalid"] = true
+                        result["message"] = validationFlags.map(x => x.message)
+                        errors += 1
+                    }
+                    
                 } else {
                     // save record if no warnings
                     // do we want to do this here, or do we only want to make any updates if all records are valid?

--- a/dlx_rest/static/js/modals/batch_edit.js
+++ b/dlx_rest/static/js/modals/batch_edit.js
@@ -1,19 +1,51 @@
-import { basket } from '../api/basket'
+//import { basket } from '../api/basket.js' 
 import { Jmarc } from '../jmarc.mjs'
 
 /* 
 Modal for batch editing records using basket functionality
 */
 
-export let batchEdit = {
-    template: `<div class="batch-edit">
-
+export let batcheditmodal = {
+    //template: `<div class="modal fade" id="batchActions" tabindex="-1" role="dialog" aria-labelledby="batchActionsModalTitle" aria-hidden="true">
+    //<div><p v-for="field in selectedFields" :key="field.id">{{field.name}}</p></div>
+    //<div><p v-for="item in basketItems" :key="item.id">{{item.name}}</p></div>
+    //</div>`,
+    template: `
+    <div v-if="show">
+        <div class="modal fade" id="batchActions" tabindex="-1" role="dialog" aria-labelledby="batchActionsModalTitle" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="batchActionsModalTitle">Batch Actions</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <div><p v-for="field in selectedFields" :key="field.id">{{field.name}}</p></div>
+                    <div><p v-for="item in basketItems" :key="item.id">{{item.name}}</p></div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                </div>
+                </div>
+            </div>
+        </div>
     </div>`,
     data: function () {
-        return {}
+        return {
+            basketItems: [],
+            selectedFields: [],
+            show: false
+        }
     },
-    created: function () {},
     methods: {
+        showModal: function() {
+            console.log("Show?", this.show)
+            this.show = true
+            console.log("Show?", this.show)
+            return true
+        },
         handleClick() {
             // Find which radio button is selected and call the corresponding function when the Update Records button is clicked
         },

--- a/dlx_rest/static/js/modals/batch_edit.js
+++ b/dlx_rest/static/js/modals/batch_edit.js
@@ -172,6 +172,7 @@ export let batcheditmodal = {
             
             // collect the promises so we can await all of them in parrallel
             let promises = []
+            let errors = 0
             
             for (let record of selectedRecords) {
                 let collection = record.split("/")[0]
@@ -211,10 +212,14 @@ export let batcheditmodal = {
                     // We have an error
                     result["invalid"] = true
                     result["message"] = validationFlags.map(x => x.message)
+                    errors += 1
                 } else {
                     // save record if no warnings
                     // do we want to do this here, or do we only want to make any updates if all records are valid?
-                    jmarc.put().catch(err => {throw err})
+                    jmarc.put().catch(err => {
+                        throw err
+                        errors += 1
+                    })
                 }
 
                 this.results.push(result)
@@ -224,7 +229,7 @@ export let batcheditmodal = {
             this.confirm = true
 
             // If nothing else has been emitted by this point, return a processed response
-            this.$emit('update-records', { "action": "add", "status": "processed", "results": this.results })  
+            this.$emit('update-records', { "message": `Added fields to ${this.results.length} record(s). ${errors} validation error(s) encountered.` , "status": "success"})  
         },
         async deleteFromAll(selectedFields, selectedRecords) {
             // Delete the selected fields from the selected records in the basket
@@ -232,6 +237,7 @@ export let batcheditmodal = {
             // by deleting the selected fields.
             // collect the promises so we can await all of them in parrallel
             let promises = []
+            let errors = 0
             
             for (let record of selectedRecords) {
                 let collection = record.split("/")[0]
@@ -256,10 +262,14 @@ export let batcheditmodal = {
                     // We have an error
                     result["invalid"] = true
                     result["message"] = validationFlags.map(x => x.message)
+                    errors += 1
                 } else {
                     // save record if no warnings
                     // do we want to do this here, or do we only want to make any updates if all records are valid?
-                    jmarc.put().catch(err => {throw err})
+                    jmarc.put().catch(err => {
+                        throw err
+                        errors += 1
+                    })
                 }
 
                 this.results.push(result)
@@ -269,7 +279,7 @@ export let batcheditmodal = {
             this.confirm = true
 
             // If nothing else has been emitted by this point, return a processed response
-            this.$emit('update-records', { "action": "delete", "status": "processed", "results": this.results } )
+            this.$emit('update-records', { "message": `Deleted fields from ${this.results.length} record(s). ${errors} validation error(s) encounterd.`, "status": "success" } )
         }
     }
 }

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -1014,11 +1014,16 @@ export let multiplemarcrecordcomponent = {
         },
         batchEdit(jmarc) {
             // Send the referring record to the modal
-            this.$refs.batcheditmodal.setReferringRecord(jmarc.collection, jmarc.recordId)
+            //this.$refs.batcheditmodal.setReferringRecord(jmarc.collection, jmarc.recordId)
+            this.$refs.batcheditmodal.referringRecord = `${jmarc.collection}/${jmarc.recordId}`
+            
             // Get the list of copied fields and send them to the batch edit modal.
-            this.$refs.batcheditmodal.updateSelectedFields(this.copiedFields)
+            //this.$refs.batcheditmodal.updateSelectedFields(this.copiedFields)
+            this.$refs.batcheditmodal.selectedFields = this.copiedFields
+
             // Reinitialize the modal
             this.$refs.batcheditmodal.confirm = false
+            this.$refs.batcheditmodal.results = []
         },
 
         ///////////////////////////////////////////////////

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -77,7 +77,7 @@ export let multiplemarcrecordcomponent = {
             </div>
 
             <!-- Modal for batch edit -->
-            <batcheditmodal ref="batcheditmodal" v-on:update-records="log($event)"></batcheditmodal>
+            <batcheditmodal ref="batcheditmodal" :api_prefix="prefix" v-on:update-records="log($event)"></batcheditmodal>
        
         <!-- Modal displaying history records -->
         <div id="modal" v-show="this.showModal">
@@ -1017,6 +1017,8 @@ export let multiplemarcrecordcomponent = {
             this.$refs.batcheditmodal.setReferringRecord(jmarc.collection, jmarc.recordId)
             // Get the list of copied fields and send them to the batch edit modal.
             this.$refs.batcheditmodal.updateSelectedFields(this.copiedFields)
+            // Reinitialize the modal
+            this.$refs.batcheditmodal.confirm = false
         },
 
         ///////////////////////////////////////////////////

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -77,7 +77,7 @@ export let multiplemarcrecordcomponent = {
             </div>
 
             <!-- Modal for batch edit -->
-            <batcheditmodal ref="batcheditmodal" :api_prefix="prefix" v-on:update-records="log($event)"></batcheditmodal>
+            <batcheditmodal ref="batcheditmodal" :api_prefix="prefix" v-on:update-records="callChangeStyling($event.message, 'd-flex w-100 alert-' + $event.status)"></batcheditmodal>
        
         <!-- Modal displaying history records -->
         <div id="modal" v-show="this.showModal">

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -77,7 +77,7 @@ export let multiplemarcrecordcomponent = {
             </div>
 
             <!-- Modal for batch edit -->
-            <batcheditmodal ref="batcheditmodal"></batcheditmodal>
+            <batcheditmodal ref="batcheditmodal" v-on:update-records="log($event)"></batcheditmodal>
        
         <!-- Modal displaying history records -->
         <div id="modal" v-show="this.showModal">
@@ -331,6 +331,10 @@ export let multiplemarcrecordcomponent = {
         });
     },
     methods: {
+
+        log(message) {
+            console.log(message);
+        },
 
         // popup warning modal if we have unsaved changes
         warningSave(){

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -1002,6 +1002,10 @@ export let multiplemarcrecordcomponent = {
             
             return this.addField(jmarc, newField, rowIndex)
         },
+        batchEdit() {
+            console.log("batch edit")
+            return true
+        },
 
         ///////////////////////////////////////////////////
         //  definition of the listeners for the shortcuts
@@ -1952,6 +1956,7 @@ export let multiplemarcrecordcomponent = {
                 {"name": "historyButton", "element": "i", "class": "fas fa-history", "title": "History",  "click": "displayHistoryModal","param":jmarc},
                 {"name": "recordViewButton", "element": "i", "class": "fas fa-filter", "title": "Record View",  "click": "displayHistoryModalToGetRecordView","params":{"jmarc": jmarc} },
                 {"name": "saveAsButton", "element": "i", "class": "fas fa-share-square", "title": "Save As Workform" ,"click": "saveToWorkform" },
+                {"name": "batchButton", "element": "i", "class": "fas fa-tasks", "title": "Batch Save", "click": "batchEdit"},
                 {"name": "removeButton", "element": "i", "class": "fas fa-window-close float-right", "title": `Close Record`, "click": "userClose"},
             ];
             if (jmarc.workformName) {

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -17,6 +17,9 @@ import { basketcomponent } from "./basket.js";
 import { countcomponent } from "./search/count.js";
 import { validationData } from "./validation.js";
 import { renderingData } from "./rendering.js";
+
+// Modals
+import { batcheditmodal } from "./modals/batch_edit.js"
  
 /////////////////////////////////////////////////////////////////
 // MARC RECORD COMPONENT
@@ -72,6 +75,9 @@ export let multiplemarcrecordcomponent = {
                     <br>&nbsp;
                 </div>
             </div>
+
+            <!-- Modal for batch edit -->
+            <batcheditmodal ref="batcheditmodal"></batcheditmodal>
        
         <!-- Modal displaying history records -->
         <div id="modal" v-show="this.showModal">
@@ -1003,8 +1009,16 @@ export let multiplemarcrecordcomponent = {
             return this.addField(jmarc, newField, rowIndex)
         },
         batchEdit() {
-            console.log("batch edit")
-            return true
+            //console.log("batch edit")
+            //for (let field of this.copiedFields) {
+            //    console.log(field)
+            //}
+            //console.log(this.$root.$refs.basketcomponent.basketItems)
+            // We just want to open the modal for batch updates with our field selections and the contents of the basket.
+
+            this.$refs.batcheditmodal.showModal();
+
+            //return true
         },
 
         ///////////////////////////////////////////////////
@@ -1956,7 +1970,7 @@ export let multiplemarcrecordcomponent = {
                 {"name": "historyButton", "element": "i", "class": "fas fa-history", "title": "History",  "click": "displayHistoryModal","param":jmarc},
                 {"name": "recordViewButton", "element": "i", "class": "fas fa-filter", "title": "Record View",  "click": "displayHistoryModalToGetRecordView","params":{"jmarc": jmarc} },
                 {"name": "saveAsButton", "element": "i", "class": "fas fa-share-square", "title": "Save As Workform" ,"click": "saveToWorkform" },
-                {"name": "batchButton", "element": "i", "class": "fas fa-tasks", "title": "Batch Save", "click": "batchEdit"},
+                {"name": "batchButton", "element": "i", "class": "fas fa-tasks", "title": "Batch Actions", "click": "batchEdit"},
                 {"name": "removeButton", "element": "i", "class": "fas fa-window-close float-right", "title": `Close Record`, "click": "userClose"},
             ];
             if (jmarc.workformName) {
@@ -2013,6 +2027,10 @@ export let multiplemarcrecordcomponent = {
                     controlButton.className = `${control["class"]} float-left p-1 record-control`;
                     controlButton.title = control["title"];
                     jmarc[control["name"]] = controlButton;
+                    if (control["name"] == "batchButton") {
+                        console.log("batch button")
+                        controlButton.setAttribute("data-toggle", "modal")
+                    }
                     if (control["param"]) {
                         controlButton.onclick = () => {
                             this[control["click"]](control["param"]) 
@@ -3203,7 +3221,8 @@ export let multiplemarcrecordcomponent = {
         }
     },
     components: {
-        'countcomponent': countcomponent
+        'countcomponent': countcomponent,
+        'batcheditmodal': batcheditmodal,
     }
 }
 

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -19,7 +19,7 @@ import { validationData } from "./validation.js";
 import { renderingData } from "./rendering.js";
 
 // Modals
-import { batcheditmodal } from "./modals/batch_edit.js"
+import {batcheditmodal} from "./modals/batch_edit.js"
  
 /////////////////////////////////////////////////////////////////
 // MARC RECORD COMPONENT
@@ -1009,16 +1009,8 @@ export let multiplemarcrecordcomponent = {
             return this.addField(jmarc, newField, rowIndex)
         },
         batchEdit() {
-            //console.log("batch edit")
-            //for (let field of this.copiedFields) {
-            //    console.log(field)
-            //}
-            //console.log(this.$root.$refs.basketcomponent.basketItems)
-            // We just want to open the modal for batch updates with our field selections and the contents of the basket.
-
-            this.$refs.batcheditmodal.showModal();
-
-            //return true
+            // Get the list of copied fields and send them to the batch edit modal.
+            this.$refs.batcheditmodal.updateSelectedFields(this.copiedFields)
         },
 
         ///////////////////////////////////////////////////
@@ -2030,6 +2022,7 @@ export let multiplemarcrecordcomponent = {
                     if (control["name"] == "batchButton") {
                         console.log("batch button")
                         controlButton.setAttribute("data-toggle", "modal")
+                        controlButton.setAttribute("data-target", "#batchActions")
                     }
                     if (control["param"]) {
                         controlButton.onclick = () => {

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -1031,8 +1031,7 @@ export let multiplemarcrecordcomponent = {
             this.$refs.batcheditmodal.selectedFields = this.copiedFields
 
             // Reinitialize the modal
-            this.$refs.batcheditmodal.confirm = false
-            this.$refs.batcheditmodal.results = []
+            this.$refs.batcheditmodal.reinitialize()
         },
 
         ///////////////////////////////////////////////////

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -1012,7 +1012,9 @@ export let multiplemarcrecordcomponent = {
             
             return this.addField(jmarc, newField, rowIndex)
         },
-        batchEdit() {
+        batchEdit(jmarc) {
+            // Send the referring record to the modal
+            this.$refs.batcheditmodal.setReferringRecord(jmarc.collection, jmarc.recordId)
             // Get the list of copied fields and send them to the batch edit modal.
             this.$refs.batcheditmodal.updateSelectedFields(this.copiedFields)
         },


### PR DESCRIPTION
Closes #1065 and adds the basket batch update functionality.

Limitation: Removing items from the basket does not update the list of available records in the popup screen, but if you need to make sure they don't accidentally appear there, you can refresh the page before initiating the batch actions workflow.