### PR TITLE
Update build-logical-fields to ensure proper logical field assignments

### DIFF
--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -461,8 +461,10 @@ export let multiplemarcrecordcomponent = {
                 // dupe auth check
                 if (jmarc.collection === "auths") {
                     let headingField = jmarc.fields.filter(x => x.tag.match(/^1/))[0];
+                    let previous = new Jmarc(jmarc.collection);
+                    previous = previous.parse(jmarc.savedState).fields.filter(x => x.tag.match(/^1/))[0];
 
-                    if (headingField) { 
+                    if (headingField && headingField.toStr() !== previous.toStr()) { 
                         // wait for the result
                         let inUse = await jmarc.authHeadingInUse().catch(error => {
                             this.callChangeStyling(error, "d-flex w-100 alert-danger");

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -461,8 +461,7 @@ export let multiplemarcrecordcomponent = {
                 // dupe auth check
                 if (jmarc.collection === "auths") {
                     let headingField = jmarc.fields.filter(x => x.tag.match(/^1/))[0];
-                    let previous = new Jmarc(jmarc.collection);
-                    previous = previous.parse(jmarc.savedState).fields.filter(x => x.tag.match(/^1/))[0];
+                    let previous = new Jmarc(jmarc.collection).parse(jmarc.savedState).fields.filter(x => x.tag.match(/^1/))[0];
 
                     if (headingField && headingField.toStr() !== previous.toStr()) { 
                         // wait for the result

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cfn-flip==1.3.0
 charset-normalizer==2.0.12
 click==8.1.2
 cryptography==41.0.0
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@09dc811f32437682e5ee12b0ac8898e63a7dd94c
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@4c5cd7c96321adecc6c32680f3409cc6968b1447
 dnspython==2.3.0
 email-validator==1.1.3
 Flask==2.1.1


### PR DESCRIPTION
Updates the dlx `build-logical-fields` script to ensure the proper `_record_type` values get assigned in the logical field index collections.

Requires dlx update and re-running `build-logical-fields`.

closes #1018 

Note: the browse indexes were already being updated properly on record commit. This effects data that was migrated/imported from other sources before the ME went live.