### PR TITLE
fix dlx version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cfn-flip==1.3.0
 charset-normalizer==2.0.12
 click==8.1.2
 cryptography==41.0.2
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@4c5cd7c96321adecc6c32680f3409cc6968b1447
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@95972bbbd3505fc7be2c44cca85b71ca87f56464
 dnspython==2.3.0
 email-validator==1.1.3
 Flask==2.1.1


### PR DESCRIPTION
It looks like while fixing merge conflicts during git merge master, you reverted the dlx commit hash to the older version. This sets it to the latest version.