### PR TITLE
preserve path and change only parameters on record open/close

### DIFF
--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -1927,7 +1927,7 @@ export let multiplemarcrecordcomponent = {
             }
 
             // update URL with current open records
-            let updatedUrl = location.href.replace(/\/editor.*/, `/editor?records=${this.recordlist.join(",")}`);
+            let updatedUrl = location.href.replace(/$/, `?records=${this.recordlist.join(",")}`);
             window.history.replaceState({}, null, updatedUrl);
 
             //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #982

This preserves any paths that are already present in the URL (e.g., foo.bar/editor/editor) and replaces only the parameters (e.g. foo.bar/editor/editor becomes for these purposes foo.bar/editor/editor/#?records=bibs/1,bibs/2)

To properly test this, you will need gunicorn (pip install gunicorn) which is not otherwise necessary for development. Then:

`SCRIPT_NAME=/editor gunicorn dlx_rest.app:app`

Now navigate to http://127.0.0.1:8000/editor/editor and open some records, noting that the full path is preserved and the records list updates properly.