### PR TITLE
Record logical fields in specified subfield order

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cfn-flip==1.3.0
 charset-normalizer==2.0.12
 click==8.1.2
 cryptography==41.0.3
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@9a45208127133cad38d5abf1a529682ee14b6efc
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@e4a17db16474b9e9d5111817258f0070aef33571
 dnspython==2.3.0
 email-validator==1.1.3
 Flask==2.1.1


### PR DESCRIPTION
Instead of recording the logical field in alphabetical order of the subfields, this records the logical field in the order specified in the logical fields config data. 

Implements [https://github.com/dag-hammarskjold-library/dlx/pull/251](https://github.com/dag-hammarskjold-library/dlx/pull/251)

closes #1183 

requires dlx update and execution of `build-logical-fields` admin task to update existing values in the system