### PR TITLE
do proper comparison on queries to fix pagination

### DIFF
--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -443,7 +443,7 @@ def search_records(coll):
     # Compare the old query with the new query; if the new query is different, reset pagination
     # if old_q contains anything at all, it returns a list, so let's make sure we're checking
     # for the first string in the list entry instead of assuming we got a string.
-    old_q = parse_qs(urlparse(request.referrer).query).get('q', [None])
+    old_q = parse_qs(urlparse(request.referrer).query).get('q', [''])
     #print(f'Old: {old_q} | New: {q}')
     if q != old_q[0]:
         start = 1
@@ -465,18 +465,18 @@ def search_records(coll):
         # Regardless of what's in the session already
         session[f"sort_{vcoll}"] = {"field": sort, "direction": direction}
         this_v = session[f"sort_{vcoll}"]
-        print(f"Got {this_v} from URL")
+        #print(f"Got {this_v} from URL")
     else:
         # See if something is in the session already
         try:
             # We have session values, so use those
             this_v = session[f"sort_{vcoll}"]
-            print(f"Got {this_v} from session")
+            #print(f"Got {this_v} from session")
             sort = session[f"sort_{vcoll}"]["field"]
             direction = session[f"sort_{vcoll}"]["direction"]
         except KeyError:
             # There is nothing in the session, so fallback to defaults
-            print(f"No sort/dir for {vcoll} found, using defaults.")
+            #print(f"No sort/dir for {vcoll} found, using defaults.")
             sort = "updated"
             direction = "desc"
     


### PR DESCRIPTION
Fixes #994

Properly compares the query string when paginating so the start doesn't get reset.