### PR TITLE
Properly update location bar for open/close records

### DIFF
--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -1810,7 +1810,8 @@ export let multiplemarcrecordcomponent = {
             }
 
             this.recordlist.splice(this.recordlist.indexOf(`${jmarc.collection}/${jmarc.recordId}`), 1);
-            let updatedUrl = location.href.replace(/\/editor.*/, `/editor?${this.recordList ? 'records=' : ''}${this.recordlist.join(",")}`);
+            //let updatedUrl = location.href.replace(/\/editor.*/, `/editor?${this.recordList ? 'records=' : ''}${this.recordlist.join(",")}`);
+            let updatedUrl = location.href.replace(/(\?.*$|$)/, `?records=${this.recordlist.join(",")}`).replace("#","");
             window.history.replaceState({}, null, updatedUrl);
 
             return true
@@ -1927,7 +1928,8 @@ export let multiplemarcrecordcomponent = {
             }
 
             // update URL with current open records
-            let updatedUrl = location.href.replace(/$/, `?records=${this.recordlist.join(",")}`);
+            let updatedUrl = location.href.replace(/(\?.*$|$)/, `?records=${this.recordlist.join(",")}`).replace("#","");
+            console.log(updatedUrl)
             window.history.replaceState({}, null, updatedUrl);
 
             //////////////////////////////////////////////////////////////////////////////

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -1929,7 +1929,6 @@ export let multiplemarcrecordcomponent = {
 
             // update URL with current open records
             let updatedUrl = location.href.replace(/(\?.*$|$)/, `?records=${this.recordlist.join(",")}`).replace("#","");
-            console.log(updatedUrl)
             window.history.replaceState({}, null, updatedUrl);
 
             //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #1253

Updates the regex for URL handling to replace the location.href when opening and closing records from the basket in the record editor.