### PR TITLE
Search string parse bugfix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cfn-flip==1.3.0
 charset-normalizer==2.0.12
 click==8.1.2
 cryptography==41.0.4
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@e4a17db16474b9e9d5111817258f0070aef33571
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@ba7d8f9cb1fdcae69db170f7c5f5bb70b2d4db17
 dnspython==2.3.0
 email-validator==1.1.3
 Flask==2.1.1


### PR DESCRIPTION
Addresses bug introduced in #1233 related to slashes in the search term. The bug prevents the search from being parsed correctly in many cases if any of the search terms contain a slash. This type of search is used in standard search as well as auth lookup