### PR TITLE
Basket Batch Update - Allow removal of selected field from batch update modal

### DIFF
--- a/dlx_rest/static/js/modals/batch_edit.js
+++ b/dlx_rest/static/js/modals/batch_edit.js
@@ -64,7 +64,7 @@ export let batcheditmodal = {
                     </div>
                     <h6 class="pt-1" v-else>These fields:</h6>
                     <div class="row">
-                        <div class="col"><p v-for="field in selectedFields" :key="field.tag">{{field.tag}} {{field.toStr()}}</p></div>
+                        <div class="col"><p v-for="field in selectedFields" :key="field.tag"><i class="fas fa-trash-alt mr-2" @click="removeField(field)" title="Remove field from list."></i>{{field.tag}} {{field.toStr()}}</p></div>
                     </div>
                     <div class="row pt-2">
                         <div class="col">
@@ -147,6 +147,11 @@ export let batcheditmodal = {
             } else {
                 this.selectedRecords.splice(this.selectedRecords.indexOf(record), 1)
             }
+        },
+        removeField(field) {
+            console.log(this.selectedRecords)
+            this.selectedFields.splice(this.selectedFields.indexOf(field), 1)
+            this.$emit('removed-field', {field: field})
         },
         select(event) {
             event.preventDefault()

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -77,7 +77,7 @@ export let multiplemarcrecordcomponent = {
             </div>
 
             <!-- Modal for batch edit -->
-            <batcheditmodal ref="batcheditmodal" :api_prefix="prefix" v-on:update-records="callChangeStyling($event.message, 'd-flex w-100 alert-' + $event.status)"></batcheditmodal>
+            <batcheditmodal ref="batcheditmodal" :api_prefix="prefix" v-on:update-records="callChangeStyling($event.message, 'd-flex w-100 alert-' + $event.status)" v-on:removed-field="removeBatchEditField($event.field)"></batcheditmodal>
        
         <!-- Modal displaying history records -->
         <div id="modal" v-show="this.showModal">
@@ -1042,6 +1042,14 @@ export let multiplemarcrecordcomponent = {
 
             // Reinitialize the modal
             this.$refs.batcheditmodal.reinitialize()
+        },
+        removeBatchEditField(field) {
+            // Unselect the field that was selected for batch editing
+            // If the field selector were using a reactive data source, we could just splice it here
+            // and be done with it, but programmatically unchecking it here would require that we 
+            // find the correct field selector on the page and uncheck that. Since we don't have it 
+            // connected to any data source, we have limited options...
+            this.copiedFields.splice(this.copiedFields.indexOf(field), 1)
         },
 
         ///////////////////////////////////////////////////


### PR DESCRIPTION
This is perhaps a workaround, but in cases where you end up with field selections that are no longer visible in the interface, you can now safely delete them from the list using an icon on the modal dialog page. 

Note that you can also remove field selections this way when they are still visibly selected on the record editor page. It's still advisable to refresh the page if you're uncertain, but in any case you can see what fields are in the selection by opening the batch edit modal dialog. 

Fixes #1263