### PR TITLE
use selected fields on current record only

### DIFF
--- a/dlx_rest/static/js/modals/batch_edit.js
+++ b/dlx_rest/static/js/modals/batch_edit.js
@@ -233,7 +233,6 @@ export let batcheditmodal = {
                 }
 
                 let validationFlags = jmarc.allValidationWarnings() // new method added to Jmarc to get flags at all levels (record, field, subfield)
-                //console.log(validationFlags)
                 result["invalid"] = false
                 if (validationFlags.length > 0) {
                     // Check if we can save on invalid; see record.js L#443 for comparison
@@ -285,21 +284,16 @@ export let batcheditmodal = {
 
                 for (let field of selectedFields) {
                     for (let targetField of jmarc.fields) {
-                        if (targetField.toStr() == field.toStr()) {
+                        if (targetField.tag == field.tag && targetField.toStr() == field.toStr()) {
                             // delete the field
                             jmarc.deleteField(targetField)
-                            //console.log("deleted the field")
-                            console.log(field.tag, field.toStr())
-                            //result["fields"].push({"field": field.tag, "subfields": subfields, "action": "will be added"})
                             result["fields"].push({"field": field.tag, "subfields":field.subfields, "action": "will be deleted"})
                         }
                     }
-                    //jmarc.deleteField(field.tag)
                     
                 }
 
                 let validationFlags = jmarc.allValidationWarnings() // new method added to Jmarc to get flags at all levels (record, field, subfield)
-                //console.log(validationFlags)
                 result["invalid"] = false
                 if (validationFlags.length > 0) {
                     // Check if we can save on invalid; see record.js L#443 for comparison

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -398,9 +398,11 @@ export let multiplemarcrecordcomponent = {
                     if (jmarc.recordId == this.selectedJmarc.recordId) {
                         this.selectedFields.push(field);
                     }
-                    this.copiedFields.push(field);                        
+                    this.copiedFields.push(field);       
+                    field.checked = true                 
                 }
             } else {
+                field.checked = false
                 if (this.copiedFields) {
                     // remove from the list of copied fields
                     // Issue #1147: splice + indexOf has trouble with objects, especially if they have any depth
@@ -409,9 +411,10 @@ export let multiplemarcrecordcomponent = {
                     {
                         this.selectedFields = this.selectedFields.filter(f => f.toStr() !== field.toStr())
                     }
-                   
+                    
                 }
             }
+            console.log(`checked? ${field.checked}`)
         },
         async saveRecord(jmarc, display=true){
             if (jmarc.workformName) {
@@ -1037,8 +1040,16 @@ export let multiplemarcrecordcomponent = {
             this.$refs.batcheditmodal.referringRecord = `${jmarc.collection}/${jmarc.recordId}`
             
             // Get the list of copied fields and send them to the batch edit modal.
-            //this.$refs.batcheditmodal.updateSelectedFields(this.copiedFields)
-            this.$refs.batcheditmodal.selectedFields = this.copiedFields
+            // this.copiedFields may have fields from more than one record, so let's check only the referring record for checked fields
+            
+            let selectedFields = []
+
+            for (let f of jmarc.fields) {
+                if (f.checked) {
+                    selectedFields.push(f)
+                }
+            }
+            this.$refs.batcheditmodal.selectedFields = selectedFields
 
             // Reinitialize the modal
             this.$refs.batcheditmodal.reinitialize()


### PR DESCRIPTION
* Use selected fields on the current record only, so users can't accidentally select fields from other (possibly closed) records.
* Match on tag name as well as field value to prevent deletion of fields that match on value but differ on tag name.

Fixes #1263