### PR TITLE
Search string parse cleanup

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -20,6 +20,7 @@ from bson import Regex, SON
 from dlx import DB, Config as DlxConfig
 from dlx.marc import MarcSet, BibSet, Bib, AuthSet, Auth, Field, Controlfield, Datafield, \
     Query, Condition, Or, InvalidAuthValue, InvalidAuthXref, AuthInUse
+from dlx.marc.query import InvalidQueryString
 from dlx.marc.query import Raw
 from dlx.file import File, Identifier
 from dlx.util import AsciiMap
@@ -217,7 +218,11 @@ class RecordsList(Resource):
         
         # search
         search = unquote(args.search) if args.search else None
-        query = Query.from_string(search, record_type=collection[:-1]) if search else Query()
+
+        try:
+            query = Query.from_string(search, record_type=collection[:-1]) if search else Query()
+        except InvalidQueryString as e:
+            abort(422, str(e))
 
         # start
         start = 1 if args.start is None else int(args.start)
@@ -369,7 +374,12 @@ class RecordsListCount(Resource):
 
         if args.search:
             search = unquote(args.search)
-            query = Query.from_string(search, record_type=collection[:-1])
+            
+            try:
+                query = Query.from_string(search, record_type=collection[:-1])
+            except InvalidQueryString as e:
+                abort(422, str(e))
+
         else:
             query = {}
         

--- a/dlx_rest/static/js/search/search.js
+++ b/dlx_rest/static/js/search/search.js
@@ -639,7 +639,7 @@ export let searchcomponent = {
                             throw new Error("Search cancelled");
                         case "all":
                             // All of the words in any field
-                            expressions.push(termList.join(" "))
+                            expressions.push(termList.map(x => x.replace(/(AND|OR|NOT)/, '"$1"')).join(" "))
                             break
                         case "exact":
                             // Exact phrase in any field
@@ -671,6 +671,7 @@ export let searchcomponent = {
                             break
                         case "all":
                             // All of the words in any field
+                            termList = (termList.map(x => x.replace(/(AND|OR|NOT)/, '"$1"')).join(" "))
                             expressions.push(`${myField}:${termList.join(" ")}`)
                             break
                         case "exact":

--- a/dlx_rest/static/js/search/search.js
+++ b/dlx_rest/static/js/search/search.js
@@ -374,34 +374,21 @@ export let searchcomponent = {
         
         fetch(this.search_url, this.abortController).then(
             response => {
-
                 if (response.ok) {
                     document.getElementById("results-spinner").remove();
                     return response.json();
-                } else {
-                    return response.text().then(
-                        text => {
-                            if (response.status === 500) {
-                                throw new Error("Invalid search")
-                            }
-                            text = text.replace(/"message":/, "");
-                            text = text.replace(/[\r\n{}:"]/g, "");
-
-                            throw new Error(text)
+                } else if (response.status === 422) {
+                    return response.json().then(
+                        json => {
+                            throw new Error(json["message"])
                         }
-                    ).catch(
-                        error => {throw error}
                     )
+                } else if (response.status == 422) {
+                    throw new Error("Internal server error");
                 }
             }
-        ).catch(
-            error => {throw error}
         ).then(
             jsonData => {
-                if (! jsonData) {
-                    throw new Error("Invalid search")
-                }
-
                 component.searchTime = (Date.now() - startTime) / 1000;
 
                 let linkKeys = Object.keys(jsonData["_links"]);
@@ -437,17 +424,6 @@ export let searchcomponent = {
                         // not implemented yet
                     }
                     component.results.push(myResult);
-
-                    /*
-                    // add the preview
-                    // too slow for large result lists
-                    Jmarc.apiUrl = component.api_prefix;
-                    Jmarc.get(component.collection, result["_id"])
-                        .then(jmarc => {
-                            console.log(jmarc.toStr());
-                            document.getElementById('link-' + result["_id"]).title = jmarc.toStr()
-                        })
-                    */
                 }
             }
         ).catch(
@@ -460,7 +436,6 @@ export let searchcomponent = {
                     this.reportError(error.toString())
                 }
             }
-
         ).then( 
             () => {
                 user.getProfile(component.api_prefix, 'my_profile').then(

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cfn-flip==1.3.0
 charset-normalizer==2.0.12
 click==8.1.2
 cryptography==41.0.4
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@bdc0a24ef52a4afabb4c909d4da686e517aa68fb
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@11e29cfe70ea9f17d96fcaefdf01a3e76140f323
 dnspython==2.3.0
 email-validator==1.1.3
 Flask==2.1.1


### PR DESCRIPTION
* Ensures that text search terms can be in any order within a search string (addresses regression introduced in release v2.9.5)
* Improved error handling and stricter enforcement of valid search syntax
* Intercept and enclose AND, OR, NOT from "all of the words" advanced search in double quotes to prevent them from being interpreted as operators

requires DLX update https://github.com/dag-hammarskjold-library/dlx/commit/11e29cfe70ea9f17d96fcaefdf01a3e76140f323

closes #1291
closes #1287