### PR TITLE
1013/1299: created date type

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cfn-flip==1.3.0
 charset-normalizer==2.0.12
 click==8.1.2
 cryptography==41.0.4
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@11e29cfe70ea9f17d96fcaefdf01a3e76140f323
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@593189bbbbb95667533a5c072dbe8ab2aed4e9b5
 dnspython==2.3.0
 email-validator==1.1.3
 Flask==2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cfn-flip==1.3.0
 charset-normalizer==2.0.12
 click==8.1.2
 cryptography==41.0.4
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@593189bbbbb95667533a5c072dbe8ab2aed4e9b5
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@2264ad0fbd22090e385d043adc2a20f6285d9ffe
 dnspython==2.3.0
 email-validator==1.1.3
 Flask==2.1.1


### PR DESCRIPTION
Implements dlx update https://github.com/dag-hammarskjold-library/dlx/pull/259 and https://github.com/dag-hammarskjold-library/dlx/pull/261

Fixes issue where the record created date is converted to a string when the record is updated. This is causing the created date to be unsearchable in these records. 

closes #1013
closes #1299 

Note: A separate ad hoc script will be run to convert the strings back to datetime objects in the records that affected up until now. 