### PR TITLE
Creation date exception handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cfn-flip==1.3.0
 charset-normalizer==2.0.12
 click==8.1.2
 cryptography==41.0.4
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@e8685a527fc88f9686f73261a808b73d0ed14fd4
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@6c4f99f50cab056b4d46a3081a4bb9ce845914a2
 dnspython==2.3.0
 email-validator==1.1.3
 Flask==2.1.1


### PR DESCRIPTION
Loosens creation date exception checking to account for records not created in the system. Fixes bug introduced in [v2.10.1-qat](https://github.com/dag-hammarskjold-library/dlx-rest/releases/tag/v2.10.1-qat)