### PR TITLE
Encode URI components in search strings for authHeadingInUse

### DIFF
--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -324,7 +324,7 @@ export class DataField {
 	
 	async lookup() {
 		let collection = this instanceof BibDataField ? "bibs" : "auths";
-		let lookupString = this.subfields.filter(x => x.value).map(x => {return `${x.code}=${x.value}`}).join("&");
+		let lookupString = this.subfields.filter(x => x.value).map(x => {return `${encodeURIComponent(x.code)}=${encodeURIComponent(x.value)}`}).join("&");
 		let url = Jmarc.apiUrl + `marc/${collection}/lookup/${this.tag}?${lookupString}`;
 
 		// determine the lookup type
@@ -1136,7 +1136,7 @@ export class Jmarc {
 		} else {
 			// other auths that have the same subfield value(s) in the heading, but
 			// could have additional subfields that make it unique
-			let url = Jmarc.apiUrl + "/marc/auths/records?search=" + encodeURIComponent(searchStr) + '&limit=' + count;
+			let url = Jmarc.apiUrl + "/marc/auths/records?search=" + encodeURIComponent(searchStr) + '&limit=' + encodeURIComponent(count);
 
 			let matches = await fetch(url)
     	    	.then(response => {

--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -1122,7 +1122,7 @@ export class Jmarc {
     	    .map(x => `${headingField.tag}__${x.code}:/^${x.value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$/`)
     	    .join(" AND ");
 
-    	let url = Jmarc.apiUrl + "/marc/auths/records/count?search=" + searchStr;
+    	let url = Jmarc.apiUrl + "/marc/auths/records/count?search=" + encodeURIComponent(searchStr);
 		let res = await fetch(url);
 		let json = await res.json();
 		let count = json['data'];
@@ -1136,7 +1136,7 @@ export class Jmarc {
 		} else {
 			// other auths that have the same subfield value(s) in the heading, but
 			// could have additional subfields that make it unique
-			let url = Jmarc.apiUrl + "/marc/auths/records?search=" + searchStr + '&limit=' + count;
+			let url = Jmarc.apiUrl + "/marc/auths/records?search=" + encodeURIComponent(searchStr) + '&limit=' + count;
 
 			let matches = await fetch(url)
     	    	.then(response => {


### PR DESCRIPTION
Fixes #1312

This applies encodeURIComponent to bare search strings in Jmarc.authHeadingInUse() so we can use additional special characters, like #

We should probably do a review of these search strings and encode the remaining ones for safety and predictability.