### PR TITLE
update search results per page options

### DIFF
--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -424,7 +424,7 @@ def get_index_list(record_type):
 @login_required
 def search_records(coll):
     api_prefix = url_for('doc', _external=True)
-    limit = request.args.get('limit', 25)
+    limit = request.args.get('limit', 250)
     start = request.args.get('start', 1)
     q = request.args.get('q', '')
 

--- a/dlx_rest/static/js/search/sort.js
+++ b/dlx_rest/static/js/search/sort.js
@@ -80,10 +80,9 @@ export let sortcomponent = {
         
         return {
             rpp: [
-                {"displayName": "10", "searchString": 10},
-                {"displayName": "25", "searchString": 25},
-                {"displayName": "50", "searchString": 50},
                 {"displayName": "100", "searchString": 100},
+                {"displayName": "250", "searchString": 250},
+                {"displayName": "500", "searchString": 500},
                 {"displayName": "1000", "searchString": 1000}
             ],
             sortFields: mySortFields,


### PR DESCRIPTION
Update the clickable options for search results per page and default. Closes #1330 