### PR TITLE
Prevent save if any auth controlled subfields are blank

### DIFF
--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -3516,7 +3516,7 @@ function keyupAuthLookup(event) {
     const inFieldCodes = field.subfields.map(x => x.code);
     const authControlledCodes = Object.keys(jmarc.authMap[field.tag]);
 
-    if (subfield.value || (authControlledCodes.length > 1 && authControlledCodes.every(x => inFieldCodes.includes(x)))) {
+    if (subfield.value || (authControlledCodes.length > 1 && inFieldCodes.every(x => authControlledCodes.includes(x)))) {
         subfield.timer = setTimeout(
             function () {
                 let dropdown = document.createElement("div");

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -415,7 +415,7 @@ export let multiplemarcrecordcomponent = {
             }
             console.log(`checked? ${field.checked}`)
         },
-        async saveRecord(jmarc, display=true){
+        async saveRecord(jmarc, display=true) {
             if (jmarc.workformName) {
                 jmarc.saveWorkform(jmarc.workformName, jmarc.workformDescription).then( () => {
                     this.removeRecordFromEditor(jmarc); // div element is stored as a property of the jmarc object
@@ -423,6 +423,18 @@ export let multiplemarcrecordcomponent = {
                     this.callChangeStyling(`Workform ${jmarc.collection}/workforms/${jmarc.workformName} saved.`, "d-flex w-100 alert-success")
                 });
             } else if (! jmarc.saved) {
+                // prevent save if any auth controlled subfields are blank
+                for (let field of jmarc.getDataFields()) {
+                    for (let subfield of field.subfields) {
+                        if (jmarc.isAuthorityControlled(field.tag, subfield.code)) {
+                            if (! subfield.xref) {
+                                this.callChangeStyling("Can't save blank authority-controlled subfield", "d-flex w-100 alert-danger")
+                                return
+                            }
+                        }
+                    }
+                }
+
                 // get rid of empty fields and validate
                 let flags = jmarc.validationWarnings();
                 

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -3406,7 +3406,7 @@ function keyupAuthLookup(event) {
 
     if (event.type === "input") {
         if (dropdown && dropdown.list) {
-            // the drodpwn list is being navigated. not sure why it triggers the inupt event
+            // the dropdown list is being navigated. not sure why it triggers the inupt event
             return
         }
 
@@ -3504,8 +3504,11 @@ function keyupAuthLookup(event) {
             }
         )
     });
- 
-    if (subfield.value) {
+    
+    const inFieldCodes = field.subfields.map(x => x.code);
+    const authControlledCodes = Object.keys(jmarc.authMap[field.tag]);
+
+    if (subfield.value || (authControlledCodes.length > 1 && authControlledCodes.every(x => inFieldCodes.includes(x)))) {
         subfield.timer = setTimeout(
             function () {
                 let dropdown = document.createElement("div");

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -3372,6 +3372,19 @@ function selectAuthority(component, subfield, choice) {
         currentSubfield.xrefCell.append(xrefLink); 
     }
 
+    // remove any existing auth controlled subfields that aren't in the new selection
+    const inChoiceCodes = choice.subfields.map(x => x.code);
+    const authControlledCodes = Object.keys(jmarc.authMap[field.tag]);
+
+    for (const subfield of field.subfields) {
+        if (authControlledCodes.includes(subfield.code) && ! inChoiceCodes.includes(subfield.code)) {
+            // Remove the subfield from the field
+            field.deleteSubfield(subfield);
+            // Remove the subfield row from the table
+            field.subfieldTable.deleteRow(subfield.row.rowIndex);
+        }
+    }
+
     // trigger unsaved changes detection and update events
     field.ind1Span.focus();
     field.ind2Span.focus();


### PR DESCRIPTION
* Prevent save if any auth controlled subfields are blank. Normally a subfield is deleted if it is saved with a blank value, so this is in order to prevent auth controlled subfields from being deleted.

* Remove existing subfields from the field if there is a new lookup selection that doesn't contain that subfield. I.e. If choosing a value that has no $g, any $g that already was in the field will be automatically removed. 
 
Closes #1259 and #1314