### PR TITLE
update dlx; auth update tigger handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cfn-flip==1.3.0
 charset-normalizer==2.0.12
 click==8.1.2
 cryptography==41.0.6
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@361ac8a0b8846625cfe17c488f4ee506b3cdf1f6
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@805accd810d00fdcd72a3e35b6ec35729fe2a02a
 dnspython==2.3.0
 email-validator==1.1.3
 Flask==2.1.1


### PR DESCRIPTION
Records attached to auth records are being saved due to irrelevant changes to the indicators of the auth heading field. Sometimes blank indicators are saved with the space character (" "), and sometimes they are saved with the underscore ("_") character. These are equivalent because they both mean blank indicator, but they were being considered as changes to the auth heading field, which triggered updates to all linked records. 

Regardless of the handling of blank indicators, changes to auth indicators should not trigger changes to the attached records anyway.

Implements https://github.com/dag-hammarskjold-library/dlx/pull/270. Requires dlx update 

Closes #1355 

