### PR TITLE
Records list API response MRK and XML format bugfix

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -263,7 +263,7 @@ class RecordsList(Resource):
             tags += (list(DlxConfig.bib_logical_fields.keys()) + list(DlxConfig.auth_logical_fields.keys()))
             project = dict.fromkeys(tags, True)
         elif fmt:
-            project = {}
+            project = None
         else:
             project = {'_id': 1}
           
@@ -290,7 +290,7 @@ class RecordsList(Resource):
         
         # exec query
         recordset = cls.from_query(query if query.conditions else {}, projection=project, skip=start-1, limit=limit, sort=sort, collation=collation, max_time_ms=Config.MAX_QUERY_TIME)
-
+        
         # process
         if fmt == 'xml':
             return Response(recordset.to_xml(), mimetype='text/xml')
@@ -419,7 +419,7 @@ class RecordsListCount(Resource):
 
         else:
             query = {}
-        
+
         links = {
             '_self': URL('api_records_list_count', collection=collection, search=args.search).to_str(),
             'related': {

--- a/dlx_rest/tests/test_api.py
+++ b/dlx_rest/tests/test_api.py
@@ -3,7 +3,7 @@ os.environ['DLX_REST_TESTING'] = 'True'
 
 import pytest, json, re
 from dlx import DB
-from dlx.marc import Bib, Auth, Datafield
+from dlx.marc import BibSet, Bib, AuthSet, Auth, Datafield
 from dlx.file import File, Identifier, S3
 from dlx_rest.app import app
 from dlx_rest.config import Config
@@ -60,7 +60,6 @@ def test_api_records_list(client, marc, users, roles, permissions, default_users
     bibGE.set('245', 'a', 'AAA')
     bibGE.set('040', 'a', 'SzGeBNU')
     
-
     # NY Auth Record
     authNY = Auth()
     authNY.set('100', 'a', 'Heading')
@@ -194,7 +193,6 @@ def test_api_records_list(client, marc, users, roles, permissions, default_users
         for i in (1, 2):
             assert f'{API}/marc/{col}/records/{i}' in data['data']
 
-    
         # search
         res = client.get(f'{API}/marc/{col}/records?search=title:\'AAA\'')
         data = check_response(res)
@@ -206,17 +204,24 @@ def test_api_records_list(client, marc, users, roles, permissions, default_users
         res = client.get(f'{API}/marc/{col}/records?sort=title&direction=asc')
         data = check_response(res)
         assert data['_meta']['returns'] == f'{API}/schemas/api.urllist'
-        
-        # Not sure why this is being tested
-        #if col == 'bibs':
-        #    assert '/records/3' in data['data'][0]
-            
+         
         # format
-        for fmt in ['mrk', 'xml']:
-            res = client.get(f'{API}/marc/{col}/records?format={fmt}')
-            assert type(res.data) == bytes
-            assert type(res.data.decode()) == str
-            
+        MarcSet = BibSet if col == 'bibs' else AuthSet
+
+        res = client.get(f'{API}/marc/{col}/records?format=mrk')
+        assert type(res.data) == bytes
+        data = res.data.decode()
+        assert type(data) == str
+        batch = MarcSet.from_mrk(data)
+        assert len(batch.records[0].fields) > 0
+
+        res = client.get(f'{API}/marc/{col}/records?format=xml')
+        assert type(res.data) == bytes
+        data = res.data.decode()
+        assert type(data) == str
+        batch = MarcSet.from_xml(data)
+        assert len(batch.records[0].fields) > 0
+    
         res = client.get(f'{API}/marc/{col}/records?format=brief')
         data = check_response(res)
         assert data['_meta']['returns'] == f'{API}/schemas/api.brieflist'


### PR DESCRIPTION
Closes #1363

Fixes records list API response MRK and XML formatting. The MongoDB query was using a projection that returned no fields in these cases.