### PR TITLE
Re-issue of PR: 

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -611,9 +611,11 @@ class Record(Resource):
             symbols = record.get_values('191', 'a') + record.get_values('191', 'z') + record.get_values('791', 'a')
             isbns = record.get_values('020', 'a')
             isbns = [x.split(' ')[0] for x in isbns] # field may have extra text after the isbn
+            # Get files by original URI which was logged in the Archive-It system
+            uris = record.get_values('561', 'u')
             all_files = []
             
-            for id_type, id_values in {'symbol': symbols, 'isbn': isbns}.items():
+            for id_type, id_values in {'symbol': symbols, 'isbn': isbns, 'uri': uris}.items():
                 for id_value in id_values:
                     langs = ('AR', 'ZH', 'EN', 'FR', 'RU', 'ES', 'DE')
                     this_id_files = list(filter(None, [File.latest_by_identifier_language(Identifier(id_type, id_value), lang) for lang in langs]))

--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -1117,9 +1117,9 @@ export class Jmarc {
 		
 		let searchStr = 
     	    headingField.subfields
-			// regex ensures exact match
-			// there is no builtin method to escape regex in JS?
-    	    .map(x => `${headingField.tag}__${x.code}:/^${x.value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$/`)
+			// regex ensures exact match since db collation may be set to case-insenstive
+			// there is no builtin method to escape regex in JS? https://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex
+    	    .map(x => `${headingField.tag}__${x.code}:/^${x.value.replace(/[.*+?^${}()\\/|[\]\\]/g, "\\$&")}$/`)
     	    .join(" AND ");
 
     	let url = Jmarc.apiUrl + "/marc/auths/records/count?search=" + searchStr;


### PR DESCRIPTION
Fixes #1204 

Adds 561 $u to the set of valid identifiers for matching files between metadata records and files collection. 

Note that this does not provide an interface to upload files this way, nor does it offer a way to distinguish between files that match by other identifiers in the same record. 