### PR TITLE
1377 patch: implement auth validation at subfield level

### DIFF
--- a/dlx_rest/static/js/import.js
+++ b/dlx_rest/static/js/import.js
@@ -250,6 +250,10 @@ export let importcomponent = {
             // Only allow one click, so we don't accidentally post multiple records
             //e.target.classList.add("disabled")            
             return jmarc.post()
+                .catch(error => {
+                    // may need some user notifcation here?
+                    throw error
+            })
         },
         filterView(e) {
             let values = [e.target.value]

--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -157,6 +157,8 @@ export class Subfield {
 		const isAuthorityControlled = jmarc.isAuthorityControlled(field.tag, this.code);
 
 		if (isAuthorityControlled) {
+			
+
 			const searchStr = 
 				field.subfields
 				.filter(x => Object.keys(authMap[jmarc.collection][field.tag]).includes(x.code))
@@ -173,8 +175,9 @@ export class Subfield {
 					} else if (recordsList.length > 1) {
 						return new Error("Ambiguous heading")
 					} else {
-						// the xref
-						return json['data']['_id']
+						// get the xref from the URL
+						const parts = recordsList[0].split("/");
+						return parts[parts.length - 1]
 					}
 				}).catch(error => {throw error})
 
@@ -238,7 +241,7 @@ export class DataField {
 					this.parentRecord.deleteField(this);
 				}
             } else if (this.tag in amap && subfield.code in amap[this.tag] && ! subfield.xref) {
-                throw new Error("Invalid authority-controlled value")
+                throw new Error(`Invalid authority-controlled value: ${this.tag} ${subfield.code} ${subfield.value}`)
             }
         }
 	}


### PR DESCRIPTION
Enables auth validation of auth controlled string values at the subfield level, so the check can be done from various contexts. Also sets the subfield xref, if a valid one can be detected.

Implements this in Jmarc.fromMrk(). `.post()` can then be called on the result of fromMrk without needing a separate method for posting the MRK string.