### PR TITLE
Newline split

### DIFF
--- a/dlx_rest/static/js/import.js
+++ b/dlx_rest/static/js/import.js
@@ -188,7 +188,7 @@ export let importcomponent = {
             let fileText = ""
             reader.readAsText(file)
             reader.onload = (res) => {
-                for (let mrk of res.target.result.split(/[\r\n]{2,}/)) {
+                for (let mrk of res.target.result.split(/(\r\n *\r\n|\n *\n)/)) {
                     Jmarc.fromMrk(mrk, this.collection).then( jmarc => {
                         // The only classes of validation errors we care about are:
                         // 1. Is there a duplicate symbol? If so, warn but allow import.

--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -740,7 +740,7 @@ export class Jmarc {
 	static async fromMrk(mrk, collection="bibs") {
 		let jmarc = new Jmarc(collection)
 
-		for (let line of mrk.split("\n")) {
+		for (let line of mrk.split(/(\r\n|\n)/)) {
 			let match = line.match(/=(\w{3})  (.*)/)
 			
 			if (match != null){


### PR DESCRIPTION
Updates the regex used to split imported MRK file for compatibility with Windows newlines.

Closes #1381 