### PR TITLE
set ssl = True in production config

### DIFF
--- a/dlx_rest/config.py
+++ b/dlx_rest/config.py
@@ -73,7 +73,7 @@ class Config(object):
         sentry_dsn = client.get_parameter(Name='sentry_dsn_prod')['Parameter']['Value']
         sentry_js_url = client.get_parameter(Name='sentry_me_js_prod')['Parameter']['Value']
         dbname = 'undlFiles'
-        ssl = False
+        ssl = True
         sync_log_collection = 'dlx_dl_log'
     else:
         raise Exception('One of the environment variables "DLX_REST_TESTING", "DLX_REST_DEV", "DLX_REST_QAT", "DLX_REST_UAT", or "DLX_REST_PRODUCTION" must return a true value in order to initialize the runtime environment')


### PR DESCRIPTION
Having it set to false causes the application to hang when running on localhost. This has been working in the past, and it's currently working in production on 2.10.7, so something else may have changed in the interim.