### PR TITLE
upgrade flask-login to support werkzeug 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ dnspython==2.6.1
 email-validator==1.1.3
 Flask==2.3.3
 Flask-Cors==3.0.10
-Flask-Login==0.6.0
+Flask-Login==0.6.3
 flask-mongoengine-3==1.0.9
 flask-restx==1.1.0
 Flask-Session==0.4.0


### PR DESCRIPTION
This will fix the broken dependabot PR (#1408) that would upgrade werkzeug to 3.0.3