### PR TITLE
use double quotes to preserve token order

### DIFF
--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -475,7 +475,7 @@ def search_records(coll):
         if re.search('[:<>]', term) is None and term not in ('AND', 'OR', 'NOT'):
             if re.match('[A-z]+/', term) and len(terms) == 1:
                 # TODO "looks like symbol" util function
-                q = f'symbol:{term.upper()}'
+                q = f'symbol:"{term.upper()}"'
 
     search_url = url_for('api_records_list', collection=coll, start=start, limit=limit, sort=sort, direction=direction, search=q, _external=True, format='brief', subtype=subtype)
 


### PR DESCRIPTION
Without quotes, the search is a text search, i.e. it splits the string by punctuation, stems the words, and does not preserve the order of the words