### PR TITLE
expose flask env and app version in admin route

### DIFF
--- a/dlx_rest/config.py
+++ b/dlx_rest/config.py
@@ -6,6 +6,7 @@ import boto3
 class Config(object):
     DEBUG = False
     TESTING = False
+    VERSION = "v2.10.10"     # Set this in each new milestone/release.
 
     bucket = 'undl-files'
     

--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -33,6 +33,12 @@ def make_sesion_permanent():
     if Config.TESTING:
         app.permanent_session_lifetime = timedelta(seconds=5)
 
+# Put some configs into the routes for debug purposes
+return_configs = {
+    "env": Config.environment,
+    "ver": Config.VERSION
+}
+
 # Main app routes
 @app.route('/')
 def index():
@@ -137,6 +143,12 @@ def admin_index():
 def get_sync_log():
     items = SyncLog.objects().order_by('-time')
     return render_template('admin/sync_log.html', title="Sync Log", items=items)
+
+@app.route('/admin/debug')
+@login_required
+@requires_permission('readAdmin')
+def get_debug():
+    return jsonify(return_configs)
 
 # Users Admin
 # Not sure if we should make any of this available to the API


### PR DESCRIPTION
Lives in /admin/debug and returns json

Could consider making an HTML landing page and linking from the admin section, as well as linking to the release notes page.

Also requires us to bump the version in the config file similar to how we're doing it for other repos.

Fixes #1369