### PR TITLE
Update certifi in dlx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cfn-flip==1.3.0
 charset-normalizer==3.3.2
 click==8.1.7
 cryptography==42.0.7
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@v1.4.3
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@v1.4.6
 dnspython==2.6.1
 email-validator==1.1.3
 exceptiongroup==1.2.1


### PR DESCRIPTION
update dlx to v1.4.7 https://github.com/dag-hammarskjold-library/dlx/releases/tag/v1.4.7