### PR TITLE
enable subtype=all from record editor and highlight all bibs collections

### DIFF
--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -459,6 +459,8 @@ def search_records(coll):
         vcoll = "speeches"
     elif request.args.get('subtype') == 'vote':
         vcoll = "votes"
+    elif request.args.get('subtype') == 'all':
+        vcoll = "all"
 
     sort =  request.args.get('sort')
     direction = request.args.get('direction') #, 'desc' if sort == 'updated' else '')

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -2173,7 +2173,7 @@ export let multiplemarcrecordcomponent = {
                         fetch(url).then(
                             response => response.json()
                         ).then( json => {
-                            controlButton.innerHTML = `(<a class="text-dark" href="${uiBase}records/bibs/search?q=xref:${jmarc.recordId}">${json.data}</a>)`
+                            controlButton.innerHTML = `(<a class="text-dark" href="${uiBase}records/bibs/search?q=xref:${jmarc.recordId}&subtype=all">${json.data}</a>)`
                             controlButton.title = "Authority use count (bibs)"
                         })
                     } else if (control["name"] == "idField") {

--- a/dlx_rest/static/js/search/count.js
+++ b/dlx_rest/static/js/search/count.js
@@ -2,7 +2,7 @@
 
 export let countcomponent = {
     props: ["api_prefix", "recordId"],
-    template: `<span class="mx-2">(<a class="result-link" :href="uiBase + 'records/bibs/search?q=xref:' + recordId">{{search_count}}</a>)</span>`,
+    template: `<span class="mx-2">(<a class="result-link" :href="uiBase + 'records/bibs/search?q=xref:' + recordId + '&subtype=all'">{{search_count}}</a>)</span>`,
     data: function() {
         let uiBase = this.api_prefix.replace("/api", "")
         return {

--- a/dlx_rest/templates/base.html
+++ b/dlx_rest/templates/base.html
@@ -80,17 +80,17 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarToggler" aria-controls="navbarToggler" aria-expanded="false" aria-label="Toggle navigation"> <span class="navbar-toggler-icon"> </span></button>
             <div class="collapse navbar-collapse" id="navbarToggler">
                 <ul class="navbar-nav mr-auto">
-                    {% if vcoll=="bibs" %}
+                    {% if (vcoll=="bibs" or vcoll=="all") %}
                         <li class="nav-item active"><a class="nav-link" href="{{url_for('get_records_list', coll='bibs')}}">Bibs</a></li>
                     {% else %}
                         <li class="nav-item"><a class="nav-link" href="{{url_for('get_records_list', coll='bibs')}}">Bibs</a></li>
                     {% endif %}
-                    {% if vcoll=="speeches" %}
+                    {% if (vcoll=="speeches" or vcoll=="all") %}
                         <li class="nav-item active"><a class="nav-link" href="{{url_for('search_records', coll='bibs', subtype='speech')}}">Speeches</a></li>
                     {% else %}
                         <li class="nav-item"><a class="nav-link" href="{{url_for('search_records', coll='bibs', subtype='speech')}}">Speeches</a></li>
                     {% endif %}
-                    {% if vcoll == "votes" %}
+                    {% if (vcoll == "votes" or vcoll=="all") %}
                         <li class="nav-item active"><a class="nav-link" href="{{url_for('search_records', coll='bibs', subtype='vote')}}">Votes</a></li>
                     {% else %}
                         <li class="nav-item"><a class="nav-link" href="{{url_for('search_records', coll='bibs', subtype='vote')}}">Votes</a></li>


### PR DESCRIPTION
Addresses a task from #1424

Do we need any similar updates in the browse lists?