### PR TITLE
Build auth cache on startup

### DIFF
--- a/dlx_rest/api/utils.py
+++ b/dlx_rest/api/utils.py
@@ -211,7 +211,6 @@ def brief_bib(record):
 
     # Should be truncated in display with hover showing the rest
     f520 = [record.get_value('520', 'a')]
-    print(f520)
 
     return {
         '_id': record.id,
@@ -323,7 +322,6 @@ def has_permission(user, action, record, collection):
                 bool_list.append("F")
     else:
         bool_list.append("F")
-    #print("boolean list:",bool_list)
     if "F" in bool_list:
         return False
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cfn-flip==1.3.0
 charset-normalizer==3.3.2
 click==8.1.7
 cryptography==42.0.7
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@v1.4.8
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@v1.4.9
 dnspython==2.6.1
 email-validator==1.1.3
 exceptiongroup==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cfn-flip==1.3.0
 charset-normalizer==3.3.2
 click==8.1.7
 cryptography==42.0.7
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@v1.4.7
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@v1.4.8
 dnspython==2.6.1
 email-validator==1.1.3
 exceptiongroup==1.2.1


### PR DESCRIPTION
Uses the dlx build cache feature to build the auth cache when the app starts up, instead of building it as lookups occur. This increases auth lookup performance.

Updates dlx to [v1.4.9](https://github.com/dag-hammarskjold-library/dlx/releases/tag/v1.4.9). This update forces records on save to look up auth values directly in the database instead of using the cache. This is in order to ensure the latest values are written to the browse indexes. 

Closes #1217 