### PR TITLE
make a new read-only record view

### DIFF
--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -575,10 +575,8 @@ def review_speeches():
 @app.route('/records/<coll>/<id>', methods=['GET'])
 @login_required
 def get_record_by_id(coll,id):
-    # register the permission, but don't require it yet, TBI
-    #register_permission('updateRecord')
     this_prefix = url_for('doc', _external=True)
-    return render_template('record.html', coll=coll, record_id=id, prefix=this_prefix)
+    return render_template('record.html', collection=coll, record_id=id, api_prefix=this_prefix)
 
 @app.route('/records/<coll>/new')
 @login_required

--- a/dlx_rest/static/js/readonly_record.js
+++ b/dlx_rest/static/js/readonly_record.js
@@ -1,0 +1,28 @@
+import { Jmarc } from "./jmarc.mjs"
+
+export let readonlyrecord = {
+    props: ["api_prefix", "collection", "record_id"],
+    template: `<div class="container">
+        <h5>{{collection}}/{{record_id}}</h5>
+        <div v-for="field in record.fields" class="field" :data-tag="field.tag">
+            <code v-if="field.subfields" class="text-primary">{{field.tag}}</code>
+            <span v-for="subfield in field.subfields">
+                <code>\${{subfield.code}}</code>{{subfield.value}}
+            </span>
+        </div>
+    </div>`,
+    data: function () {
+        return {
+            record: {}
+        }
+    },
+    created: function () {
+        Jmarc.apiUrl = this.api_prefix
+
+        let promise = Jmarc.get(this.collection, this.record_id)
+
+        promise.then( jmarc => {
+            this.record = jmarc
+        })
+    }
+}

--- a/dlx_rest/static/js/readonly_record.js
+++ b/dlx_rest/static/js/readonly_record.js
@@ -3,9 +3,10 @@ import { Jmarc } from "./jmarc.mjs"
 export let readonlyrecord = {
     props: ["api_prefix", "collection", "record_id"],
     template: `<div class="container">
-        <h5>{{collection}}/{{record_id}}</h5>
+        <h5>{{record.getVirtualCollection()}}/{{record_id}}</h5>
         <div v-for="field in record.fields" class="field" :data-tag="field.tag">
-            <code v-if="field.subfields" class="text-primary">{{field.tag}}</code>
+            <code class="text-primary">{{field.tag}}</code>
+            <span v-if="!field.subfields">{{field.value}}</span>
             <span v-for="subfield in field.subfields">
                 <code>\${{subfield.code}}</code>{{subfield.value}}
             </span>

--- a/dlx_rest/templates/record.html
+++ b/dlx_rest/templates/record.html
@@ -1,11 +1,16 @@
 {% extends 'base.html' %} {% block content %}    
 
     <div id="record_vm" v-show="true" data-api_prefix="{{prefix}}">
-        <headercomponent></headercomponent>
-        <messagecomponent prefix="{{prefix}}"></messagecomponent>
-        <multiplemarcrecordcomponent prefix="{{prefix}}" records="{{coll}}/{{record_id}}" readonly></multiplemarcrecordcomponent>
+        <readonlyrecord api_prefix="{{api_prefix}}" collection="{{collection}}" record_id="{{record_id}}"></readonlyrecord>
     </div>
 
-<script type="module" src="{{url_for('static', filename='js/record_vm.js')}}" ></script>
+<script type="module">
+    import {readonlyrecord} from "{{url_for('static', filename='js/readonly_record.js')}}"
+
+    export let readonly_vm = new Vue({
+        el: "#record_vm",
+        components: {readonlyrecord}
+    })
+</script>
 
 {% endblock %}

--- a/dlx_rest/templates/record.html
+++ b/dlx_rest/templates/record.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %} {% block content %}    
 
+    {% set records="/".join([collection,record_id]) %}
+    <div class="container"><a href="{{url_for('editor', records=records)}}">Edit</a></div>
     <div id="record_vm" v-show="true" data-api_prefix="{{prefix}}">
         <readonlyrecord api_prefix="{{api_prefix}}" collection="{{collection}}" record_id="{{record_id}}"></readonlyrecord>
     </div>


### PR DESCRIPTION
Fixes #1466 

We inadvertently messed up the read-only record view. Originally I thought it was because of JS cleanup, but now I think it's something else. This PR offers a new read-only view, which is only applicable to situations in which the record is in someone else's basket already, otherwise the link takes you straight to the editor. It's a proposal, but if it's not needed or needs change we can figure out another approach.