### PR TITLE
preserve output fields and discard subfield specifier

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -300,7 +300,7 @@ class RecordsList(Resource):
             project = None
             output_fields = args.get("fields")
             if output_fields is not None:
-                tags = [f.strip() for  f in output_fields.split(',')]
+                tags = [f.strip().split('__')[0] for  f in output_fields.split(',')]
                 # make sure logical fields are available for sorting
                 tags += (list(DlxConfig.bib_logical_fields.keys()) + list(DlxConfig.auth_logical_fields.keys()))
                 project = dict.fromkeys(tags, True)

--- a/dlx_rest/static/js/modals/export.js
+++ b/dlx_rest/static/js/modals/export.js
@@ -76,6 +76,7 @@ export let exportmodal = {
           this.selectedExportUrl = this.links.format[format.toUpperCase()]
           let url = new URL(this.selectedExportUrl)
           let search = new URLSearchParams(url.search)
+          search.set("fields", this.selectedFields)
           search.set("start", 1)
           search.set("limit", 100)
           //search.set("listtype", "export")


### PR DESCRIPTION
Preserves output field selection when the format changes.

Allows users to include subfield specifier (__a) but discards it since we don't have a way to handle it yet.