### PR TITLE
default fields/selectedFields to empty string instead of null

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -298,9 +298,10 @@ class RecordsList(Resource):
             project = dict.fromkeys(tags, True)
         elif fmt in ['mrk', 'xml', 'csv']:
             project = None
-            output_fields = args.get("fields")
-            if output_fields is not None:
+
+            if output_fields := args.get("fields"):
                 tags = [f.strip().split('__')[0] for  f in output_fields.split(',')]
+                
                 # make sure logical fields are available for sorting
                 tags += (list(DlxConfig.bib_logical_fields.keys()) + list(DlxConfig.auth_logical_fields.keys()))
                 project = dict.fromkeys(tags, True)

--- a/dlx_rest/static/js/modals/export.js
+++ b/dlx_rest/static/js/modals/export.js
@@ -61,7 +61,7 @@ export let exportmodal = {
             showModal: false,
             showSpinner: false,
             selectedFormat: 'mrk',
-            selectedFields: null,
+            selectedFields: '',
             selectedExportUrl: null,
             currentPage: null
         }
@@ -72,16 +72,16 @@ export let exportmodal = {
             this.setFormat('mrk')
         },
         setFormat(format) {
-          this.selectedFormat = format
-          this.selectedExportUrl = this.links.format[format.toUpperCase()]
-          let url = new URL(this.selectedExportUrl)
-          let search = new URLSearchParams(url.search)
-          search.set("fields", this.selectedFields)
-          search.set("start", 1)
-          search.set("limit", 100)
-          //search.set("listtype", "export")
-          url.search = search
-          this.selectedExportUrl = url
+            this.selectedFormat = format
+            this.selectedExportUrl = this.links.format[format.toUpperCase()]
+            let url = new URL(this.selectedExportUrl)
+            let search = new URLSearchParams(url.search)
+            search.set("fields", this.selectedFields)
+            search.set("start", 1)
+            search.set("limit", 100)
+            //search.set("listtype", "export")
+            url.search = search
+            this.selectedExportUrl = url
         },
         setOutputFields(e) {
             this.selectedFields = e.target.value


### PR DESCRIPTION
The string "null" is being sent to the API fields parameter when no fields are specified to export. Instead we need a blank string. This was causing no fields to be exported when no fields are specified by the user. 