### PR TITLE
remove bib filters from auth search page

### DIFF
--- a/dlx_rest/static/js/search/sort.js
+++ b/dlx_rest/static/js/search/sort.js
@@ -57,7 +57,7 @@ export let sortcomponent = {
     </div>
     `,
     data: function() {
-        let vcoll = "bibs"
+        let vcoll = this.collection
         if (this.params.search) {
             /* TODO get query "type" from backend [not implemented yet] */
             for (let term of this.params.search.split(/ +/)) {


### PR DESCRIPTION
The bib search filters were showing up on the auth search page because sort.js was defaulting to "bibs" for the "vcoll" value.