### PR TITLE
Sort by heading fix

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -313,7 +313,6 @@ class RecordsList(Resource):
           
         # sort
         sort_by = args.get('sort') or 'updated'
-        sort_by = 'subject' if sort_by == 'heading' else sort_by
         sort_by = 'symbol' if sort_by == 'meeting record' else sort_by
         sort_by = 'date' if sort_by == 'meeting date' else sort_by
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cfn-flip==1.3.0
 charset-normalizer==3.3.2
 click==8.1.7
 cryptography==43.0.1
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@v1.4.16.1
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@v1.4.16.2
 dnspython==2.6.1
 email-validator==1.1.3
 exceptiongroup==1.2.1


### PR DESCRIPTION
Uses the new "heading" logical field for authority records search results sort instead of "subject".

Closes #1540 