### PR TITLE
Prune requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ aniso8601==9.0.1
 blinker==1.7.0
 cachelib==0.13.0
 cfn-flip==1.3.0
-charset-normalizer==3.3.2
 dlx @ git+https://github.com/dag-hammarskjold-library/dlx@v1.4.16.3
 email-validator==1.1.3
 Flask==2.3.3
@@ -21,5 +20,4 @@ python-ulid==1.1.0
 sentry-sdk==2.8.0
 troposphere==4.0.1
 WTForms==3.0.1
-xmltodict==0.13.0
 zipp==3.19.1


### PR DESCRIPTION
Similar to other repos, a few requirements can be removed here to allow dlx to control the version of its dependencies.