### PR TITLE
Move test matrix and update actions versions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -5,7 +5,7 @@ name: Python package
 
 on:
   pull_request:
-    types: [ opened, synchronize, reponend ]
+    types: [ opened, synchronize, reopened ]
     
 env:
   DLX_REST_TESTING: True
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     


### PR DESCRIPTION
Drops python 3.8, adds 3.12, fixes a typo in the PR type specifications, and bumps GitHub actions versions