### PR TITLE
Bump flask-restx from 1.1.0 to 1.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask==2.3.3
 Flask-Cors==4.0.2
 Flask-Login==0.6.3
 flask-mongoengine-3==1.0.9
-flask-restx==1.1.0
+flask-restx==1.3.0
 Flask-Session==0.4.0
 Flask-WTF==1.2.1
 importlib-metadata==4.11.3


### PR DESCRIPTION
flask-restx 1.1.0 was incompatible with werkzeug 3.1x, which we updated in dlx recently.