### PR TITLE
exception handling

### DIFF
--- a/dlx_rest/static/js/basket.js
+++ b/dlx_rest/static/js/basket.js
@@ -204,7 +204,8 @@ export let basketcomponent = {
                 ).catch(
                     error => {
                         // alert that debugging is needed
-                        this.callChangeStyling(`Basket item ${element.collection} / ${element.record_id} failed to load`, "d-flex w-100 alert-danger")
+                        this.callChangeStyling(`Basket item ${element.collection} / ${element.record_id} failed to load`, "d-flex w-100 alert-danger");
+                        throw error;
                     }
                 )
             }


### PR DESCRIPTION
* Tries to catch all errors in jmarc.mjs fetch requests
* Removes use of regex in authority in use check
* API query routes (search/count) abort with 408 on query timeouts instead of throwing Python exception

Closes #1568