### PR TITLE
Speech review load handling

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -281,7 +281,7 @@ class RecordsList(Resource):
         # format
         fmt = args['format'] or None
 
-        if limit > 10_000:
+        if limit > 1000:
             abort(404, 'Maximum limit is 1000')
         
         if fmt == 'brief':

--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -281,7 +281,7 @@ class RecordsList(Resource):
         # format
         fmt = args['format'] or None
 
-        if fmt != 'brief_speech' and limit > 1000:
+        if limit > 10_000:
             abort(404, 'Maximum limit is 1000')
         
         if fmt == 'brief':

--- a/dlx_rest/static/js/speech_review.js
+++ b/dlx_rest/static/js/speech_review.js
@@ -174,10 +174,12 @@ export let speechreviewcomponent = {
                 return
             }
 
-            let next = `${this.api_prefix}marc/bibs/records?search=${this.searchTerm}&subtype=speech&format=brief_speech`;
+            this.speeches = []
+            this.showSpinner = true
             const startTime = Date.now();
             const seenIds = []; // temporarily necessasry due to pagination bug https://github.com/dag-hammarskjold-library/dlx-rest/issues/1586
-            
+            let next = `${this.api_prefix}marc/bibs/records?search=${this.searchTerm}&subtype=speech&format=brief_speech`;
+
             while (1) {
                 let records;
 
@@ -190,7 +192,7 @@ export let speechreviewcomponent = {
                     // todo: alert user there was an error
                     throw e
                 });
-                
+
                 if (records.length === 0) {
                     break
                 }

--- a/dlx_rest/static/js/speech_review.js
+++ b/dlx_rest/static/js/speech_review.js
@@ -174,16 +174,18 @@ export let speechreviewcomponent = {
                 return
             }
 
-            let seen = 0;
-            let startTime = Date.now();
-            let seenIds = []; // temporarily necessasry due to pagination bug https://github.com/dag-hammarskjold-library/dlx-rest/issues/1586
+            let next = `${this.api_prefix}marc/bibs/records?search=${this.searchTerm}&subtype=speech&format=brief_speech`;
+            const startTime = Date.now();
+            const seenIds = []; // temporarily necessasry due to pagination bug https://github.com/dag-hammarskjold-library/dlx-rest/issues/1586
             
             while (1) {
-                const search_url = `${this.api_prefix}marc/bibs/records?search=${this.searchTerm}&subtype=speech&format=brief_speech&start=${seen + 1}&limit=${100}`;
-                const records = await fetch(search_url).then(response => {
+                let records;
+
+                await fetch(next).then(response => {
                     return response.json()
                 }).then(json => {
-                    return json['data']
+                    next = json['_links']['_next']
+                    records = json['data']
                 }).catch(e => {
                     // todo: alert user there was an error
                     throw e
@@ -199,8 +201,6 @@ export let speechreviewcomponent = {
                         this.speeches.push(record);
                     }
                 });
-
-                seen += records.length;
             }
 
             this.searchTime = (Date.now() - startTime) / 1000;

--- a/dlx_rest/static/js/speech_review.js
+++ b/dlx_rest/static/js/speech_review.js
@@ -20,7 +20,8 @@ export let speechreviewcomponent = {
             <div class="input-group mb-3">
                 <input id="speechSearch" type="text" class="form-control" aria-label="Search Speeches" v-model="searchTerm" @keyup="updateSearchQuery">
                 <div class="input-group-append">
-                    <a class="btn btn-outline-secondary" type="button" @click="submitSearch">Submit</a>
+                    <a v-if="searchTerm" class="btn btn-outline-secondary" type="button" @click="submitSearch">Submit</a>
+                    <a v-else class="btn" style="color: lightgray" type="button" disabled>Submit</a>
                 </div>
             </div>
         </form>
@@ -168,6 +169,11 @@ export let speechreviewcomponent = {
             window.history.replaceState(null, "", url)
         },
         submitSearch() {
+            if (!this.searchTerm) {
+                window.alert("Search term required");
+                return
+            }
+
             // Do the search and update this.speeches
             let search_url = `${this.api_prefix}marc/bibs/records?search=${this.searchTerm}&subtype=speech&format=brief_speech&start=1&limit=50000`
             let ui_url = `${this.api_prefix.replace("/api/","")}/records/speeches/review?q=${this.foundQ}`

--- a/dlx_rest/static/js/speech_review.js
+++ b/dlx_rest/static/js/speech_review.js
@@ -106,8 +106,8 @@ export let speechreviewcomponent = {
     <previewmodal ref="previewmodal" :api_prefix="api_prefix" collection_name="Speeches"></previewmodal>
     <agendamodal ref="agendamodal" :api_prefix="api_prefix"></agendamodal>
 </div>`,
-    data: function() {
-        let myUIBase = this.api_prefix.replace('/api/','')
+    data: function () {
+        let myUIBase = this.api_prefix.replace('/api/', '')
         return {
             speeches: [],
             submitted: false,
@@ -126,7 +126,7 @@ export let speechreviewcomponent = {
         // This function performs multifield sort using the objects stored in the sortColumns array
         // What goes in the sortColumns array, in what order, and how it gets there is handled by processSort() below
         sortedSpeeches: function () {
-            return this.speeches.sort( (a, b) => {
+            return this.speeches.sort((a, b) => {
                 // For each object in sortColumns, we want to perform the sort
                 // Each object is a defined column that exists in the incoming data
                 for (const i in this.sortColumns) {
@@ -159,7 +159,7 @@ export let speechreviewcomponent = {
     },
     methods: {
         async refreshBasket() {
-            basket.getBasket(this.api_prefix).then( (b) => {
+            basket.getBasket(this.api_prefix).then((b) => {
                 this.myBasket = b
             })
         },
@@ -174,42 +174,46 @@ export let speechreviewcomponent = {
                 return
             }
 
-            // Do the search and update this.speeches
-            // get the count
-            const countUrl = `${this.api_prefix}marc/bibs/records/count?search=${this.searchTerm}&subtype=speech`;
-            const count = await fetch(countUrl).then(response => {
-                return response.json()
-            }).then(json => {
-                return json['data']
-            }).catch(e => {throw e});
-
             let seen = 0;
             let startTime = Date.now();
-            this.showSpinner = true;
-
-            while (seen < count) {
-                const search_url = `${this.api_prefix}marc/bibs/records?search=${this.searchTerm}&subtype=speech&format=brief_speech&start=${seen+1}&limit=${100}`;
+            let seenIds = []; // temporarily necessasry due to pagination bug https://github.com/dag-hammarskjold-library/dlx-rest/issues/1586
+            
+            while (1) {
+                const search_url = `${this.api_prefix}marc/bibs/records?search=${this.searchTerm}&subtype=speech&format=brief_speech&start=${seen + 1}&limit=${100}`;
                 const records = await fetch(search_url).then(response => {
                     return response.json()
                 }).then(json => {
                     return json['data']
-                }).catch(e => {throw e});
+                }).catch(e => {
+                    // todo: alert user there was an error
+                    throw e
+                });
+                
+                if (records.length === 0) {
+                    break
+                }
 
-                records.forEach(record => {this.speeches.push(record)});
-                seen += records.length; 
+                records.forEach(record => {
+                    if (!seenIds.includes(record._id)) {
+                        seenIds.push(record._id);
+                        this.speeches.push(record);
+                    }
+                });
+
+                seen += records.length;
             }
-            
+
             this.searchTime = (Date.now() - startTime) / 1000;
             this.showSpinner = false;
-            let ui_url = `${this.api_prefix.replace("/api/","")}/records/speeches/review?q=${this.foundQ}`
-            window.history.replaceState({},ui_url);
+            let ui_url = `${this.api_prefix.replace("/api/", "")}/records/speeches/review?q=${this.foundQ}`
+            window.history.replaceState({}, ui_url);
         },
         toggleSelect(e) {
             let recordId = e.target.dataset.recordid
-            if (this.selectedRecords.includes({"collection": "bibs", "record_id": recordId})) {
-                this.selectedRecords.splice(this.selectedRecords.indexOf({"collection": "bibs", "record_id": recordId}),1)
+            if (this.selectedRecords.includes({ "collection": "bibs", "record_id": recordId })) {
+                this.selectedRecords.splice(this.selectedRecords.indexOf({ "collection": "bibs", "record_id": recordId }), 1)
             } else {
-                this.selectedRecords.push({"collection": "bibs", "record_id": recordId})
+                this.selectedRecords.push({ "collection": "bibs", "record_id": recordId })
             }
         },
         selectAll() {
@@ -217,7 +221,7 @@ export let speechreviewcomponent = {
                 i.disabled ? i.checked = false : i.checked = true
                 let recordId = i.dataset.recordid
                 if (i.checked) {
-                    this.selectedRecords.push({"collection": "bibs", "record_id": recordId})
+                    this.selectedRecords.push({ "collection": "bibs", "record_id": recordId })
                 }
             }
         },
@@ -227,7 +231,7 @@ export let speechreviewcomponent = {
             }
             this.selectedRecords = []
         },
-        processSort: function(e, column) {
+        processSort: function (e, column) {
             // reset sort indicators
             for (let i of document.getElementsByTagName("i")) {
                 i.classList.replace("text-dark", "text-secondary")
@@ -250,17 +254,17 @@ export let speechreviewcomponent = {
                         // Otherwise we are changing the sort direction
                         existingColumn.direction = direction
                     }
-                } else {                    
+                } else {
                     existingColumn.direction == "asc" ? existingColumn.direction = "desc" : existingColumn.direction = "asc"
                     this.sortColumns = [existingColumn]
                 }
             } else {
                 if (e.shiftKey) {
                     // There was no existing column, and we want to add this to our list of columns
-                    this.sortColumns.push({column: column, direction: "asc"})
+                    this.sortColumns.push({ column: column, direction: "asc" })
                 } else {
                     // There was no existing column, and we want to make this our only sort column
-                    this.sortColumns = [{column:column, direction:"asc"}]
+                    this.sortColumns = [{ column: column, direction: "asc" }]
                 }
             }
             // Finally, go through the DOM and update the icons and badges according to the contents of sortColumns
@@ -286,7 +290,7 @@ export let speechreviewcomponent = {
             4. Update the folder icon for each item sent to the basket
             5. Empty this.selectedRecords
             */
-            basket.createItems(this.api_prefix, 'userprofile/my_profile/basket', JSON.stringify(this.selectedRecords)).then( () => {
+            basket.createItems(this.api_prefix, 'userprofile/my_profile/basket', JSON.stringify(this.selectedRecords)).then(() => {
                 for (let record of this.selectedRecords) {
                     let checkbox = document.querySelector(`input[data-recordid="${record.record_id}"]`)
                     checkbox.checked = false
@@ -302,7 +306,7 @@ export let speechreviewcomponent = {
         toggleBasket: async function (e, speechId) {
             if (e.target.classList.contains("fa-folder-plus")) {
                 // add to basket
-                await basket.createItem(this.api_prefix, 'userprofile/my_profile/basket', "bibs", speechId).then( () => {
+                await basket.createItem(this.api_prefix, 'userprofile/my_profile/basket', "bibs", speechId).then(() => {
                     let checkbox = document.querySelector(`input[data-recordid="${speechId}"]`)
                     checkbox.disabled = true
                     e.target.classList.remove("fa-folder-plus")
@@ -310,7 +314,7 @@ export let speechreviewcomponent = {
                 })
             } else {
                 // remove from basket
-                await basket.deleteItem(this.myBasket, "bibs", speechId).then( () => {
+                await basket.deleteItem(this.myBasket, "bibs", speechId).then(() => {
                     let checkbox = document.querySelector(`input[data-recordid="${speechId}"]`)
                     checkbox.disabled = false
                     e.target.classList.remove("fa-folder-minus")
@@ -338,7 +342,7 @@ export let speechreviewcomponent = {
         },
     },
     components: {
-        'sortcomponent': sortcomponent, 
+        'sortcomponent': sortcomponent,
         'countcomponent': countcomponent,
         'previewmodal': previewmodal,
         'agendamodal': agendamodal


### PR DESCRIPTION
* Prevents searches with no search term (tries to retrieve all records)
* Restores limit of 1000 records to all API record list requests
* Gathers speech records for speech review page by page in order to reduce load on the server side

Closes #1575 