### PR TITLE
Implement additional feedback for Metadata Import

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -1734,6 +1734,7 @@ class MyUserProfileRecord(Resource):
         this_u = User.objects.get(id=current_user.id)
         user_id = this_u['id']
         return_data['email'] = this_u.email
+        return_data['shortname'] = this_u.shortname
         return_data['roles'] = []
         return_data['default_views'] = []
             

--- a/dlx_rest/commands.py
+++ b/dlx_rest/commands.py
@@ -78,9 +78,12 @@ def init_roles():
             this_permission = Permission(action=f'{action}{comp}')
             this_permission.save()
             admin_permissions.append(this_permission)
+
+    import_marc = Permission(action='importMarc')
     
     admin_permissions.append(auth_review)
     admin_permissions.append(merge_auth)
+    admin_permissions.append(import_marc)
     admin_role = Role(name="admin")
     admin_role.permissions = admin_permissions
     admin_role.save()
@@ -144,6 +147,8 @@ def init_roles():
     coll_admin = Role(name=f'bibs-NY-indexer')
     coll_admin.permissions = coll_perms
     coll_admin.save()
+
+    # To do: init the batch admin role
 
     # Resetting previously existing roles
     for r in user_roles:

--- a/dlx_rest/forms.py
+++ b/dlx_rest/forms.py
@@ -20,6 +20,7 @@ class RegisterForm(FlaskForm):
 class CreateUserForm(FlaskForm):
     email = StringField('Email', validators=[DataRequired()])
     username = StringField('Username', validators=[DataRequired()])
+    shortname = StringField('Short Name', validators=[DataRequired()])
     password = PasswordField('Password', validators=[DataRequired()])
     # To do: Make this list come from the database.
     roles = SelectMultipleField('Roles')
@@ -29,6 +30,7 @@ class CreateUserForm(FlaskForm):
 class UpdateUserForm(FlaskForm):
     email = StringField('Email', validators=[DataRequired()])
     username = StringField('Username', validators=[DataRequired()])
+    shortname = StringField('Short Name', validators=[DataRequired()])
     password = PasswordField('Password', validators=[DataRequired()])
     # To do: Make this list come from the database.
     roles = SelectMultipleField('Roles')

--- a/dlx_rest/models.py
+++ b/dlx_rest/models.py
@@ -68,6 +68,7 @@ class RecordView(Document):
 class User(UserMixin, Document):
     email = StringField(max_length=200, required=True, unique=True)
     username = StringField(max_length=200, required=True)
+    shortname = StringField(max_length=3, required=True)
     password_hash = StringField(max_length=200)
     roles = ListField(ReferenceField(Role))
     default_views = ListField(ReferenceField(RecordView))

--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -170,6 +170,7 @@ def create_user():
     if request.method == 'POST':
         email = request.form.get('email')
         username = request.form.get('username')
+        shortname = request.form.get('shortname')
         roles = form.roles.data
         default_views = form.views.data
         password = request.form.get('password')
@@ -178,6 +179,7 @@ def create_user():
         user = User(email=email, created=created)
         user.set_password(password)
         user.username = username
+        user.shortname = shortname
         for role in roles:
             try:
                 r = Role.objects.get(name=role)
@@ -219,12 +221,14 @@ def update_user(id):
         user = User.objects.get(id=id)
         email = request.form.get('email', user.email)
         username = request.form.get('username', user.username)
+        shortname = request.form.get('shortname')
         roles = request.form.getlist('roles')
         default_views = request.form.getlist('views')
         password = request.form.get('password', user.password_hash)
 
         user.email = email  #unsure if this is a good idea
         user.username = username
+        user.shortname = shortname
         if password:
             user.set_password(password)
         user.roles = []
@@ -785,7 +789,7 @@ def update_file():
 
 @app.route('/import')
 @login_required
-#@requires_permission('importMarc')
+@requires_permission('importMarc')
 def import_marc():
     this_prefix = url_for('doc', _external=True)
     print(this_prefix)

--- a/dlx_rest/static/js/import.js
+++ b/dlx_rest/static/js/import.js
@@ -1,4 +1,5 @@
 import { Jmarc } from './jmarc.mjs'
+import user from "./api/user.js"
 
 export let importcomponent = {
     props: ["api_prefix"],
@@ -140,12 +141,17 @@ export let importcomponent = {
             uiBase: "",
             showErrors: false,
             detectedSpinner: false,
-            selected: 0
+            selected: 0,
+            userShort: null,
+            myProfile: {}
         }
     },
-    created: function () {
+    created: async function () {
         Jmarc.apiUrl = this.api_prefix
         this.uiBase = this.api_prefix.replace("/api", "")
+        this.myProfile = await user.getProfile(this.api_prefix, 'my_profile')
+        // We only need the shortname of the user
+        this.userShort = this.myProfile.data.shortname
     },
     computed: {
         unimportableRecords: function () {
@@ -254,7 +260,8 @@ export let importcomponent = {
                             let importField = jmarc.createField("999")
                             let importSubfield = importField.createSubfield("a")
                             const today = new Date()
-                            importSubfield.value = `import${today.getFullYear()}${today.getMonth() + 1}${today.getDate()}`
+                            // user shortname
+                            importSubfield.value = `${this.userShort}i${today.getFullYear()}${today.getMonth() + 1}${today.getDate()}`
                             importField.new = true
 
                             this.records.push({ "jmarc": jmarc, "mrk": mrk, "validationErrors": validationErrors, "fatalErrors": fatalErrors, "checked": false })

--- a/dlx_rest/templates/admin/createuser.html
+++ b/dlx_rest/templates/admin/createuser.html
@@ -23,6 +23,11 @@
         </div>
         <div class="form-group">
             <p>
+                {{ form.shortname.label }}<br> {{ form.shortname(size=3,class="form-control") }}
+            </p>
+        </div>
+        <div class="form-group">
+            <p>
                 {{ form.password.label }}<br> {{ form.password(class="form-control") }}
             </p>
         </div>

--- a/dlx_rest/templates/admin/edituser.html
+++ b/dlx_rest/templates/admin/edituser.html
@@ -23,6 +23,11 @@
         </div>
         <div class="form-group">
             <p>
+                {{ form.shortname.label }}<br> {{ form.shortname(size=3,class="form-control") }}
+            </p>
+        </div>
+        <div class="form-group">
+            <p>
                 {{ form.password.label }}<br> {{ form.password(class="form-control", value=user.password_hash) }}
             </p>
         </div>

--- a/dlx_rest/templates/admin/users.html
+++ b/dlx_rest/templates/admin/users.html
@@ -5,6 +5,7 @@
         <thead>
             <th>Email</th>
             <th>Username</th>
+            <th>Short Name</th>
             <th>Roles</th>
             <th>Default Views</th>
             <th>Actions</th>
@@ -14,19 +15,21 @@
             <tr>
                 <td>{{user.email}}</td>
                 <td>{{user.username}}</td>
+                <td>{{user.shortname}}</td>
                 <td>
                     {% for role in user.roles %}
-                        {{role.name}}{{ ", " if not loop.last else "" }}
+                    {{role.name}}{{ ", " if not loop.last else "" }}
                     {% endfor %}
                 </td>
                 <td>
                     {% for v in user.default_views %}
-                        {{v.collection}}/{{v.name}}
+                    {{v.collection}}/{{v.name}}
                     {% endfor %}
                 </td>
                 <td>
                     <i class="fas fa-edit"><a href="{{url_for('update_user', id=user.id)}}"> Edit</a></i> |
-                    <i class="fas fa-trash-alt"><a href="{{url_for('delete_user', id=user.id)}}"> Delete</a></i></td>
+                    <i class="fas fa-trash-alt"><a href="{{url_for('delete_user', id=user.id)}}"> Delete</a></i>
+                </td>
             </tr>
             {% endfor %}
             <tr>


### PR DESCRIPTION
Addresses the remaining feedback items from #1426 

1. Enables the required permission importMarc on the import route.
2. Adds a short name field so we can collect 999 $a values like {shortname}{action}{date}.

Note that to use the permission, we will need to create a new role. In dev, this is "import-admin", which has the same permissions as indexer-admin. The admin role also has access to this permission. 

Additionally note that each user will need to be edited to include a shortname. 

Neither of these are development concerns, but need to be noted as setup tasks after deployment.