### PR TITLE
Update dlx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aniso8601==9.0.1
 blinker==1.9.0
 cachelib==0.13.0
 cfn-flip==1.3.0
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@v1.4.20
+dlx @ git+https://github.com/dag-hammarskjold-library/dlx@v1.4.21
 email-validator==2.2.0
 Flask==3.1.0
 Flask-Cors==5.0.0


### PR DESCRIPTION
[dlx 1.4.21](https://github.com/dag-hammarskjold-library/dlx/releases/tag/v1.4.21) update closes #1314 and closes #1524. https://github.com/dag-hammarskjold-library/dlx-rest/issues/1404 is related by remains open