### PR TITLE
Search results and record preview design tweaks

### DIFF
--- a/dlx_rest/static/css/search.css
+++ b/dlx_rest/static/css/search.css
@@ -3,23 +3,52 @@ a.result-link {
     color: #0000EE
 }
 
+div.search-result {
+    background-color: #F8F8F8;
+
+}
+
+div.search-result:hover {
+    background-color: gainsboro;
+}
+
+i.preview-toggle:hover {
+    cursor: pointer
+}
+
 div.record-preview {
     position: absolute;
     display: block;
     z-index: 1;
     background: rgba(255, 255, 255, 0.95);
     border: 1px solid black;
+    left: 9%;
+    width: 763px;
     box-shadow: -1px 2px 2px gray;
 }
 
-span.record-preview-id {
-    font-weight: bold;
-    font-style: italic;
+div.files-container {
+    display: block;
 }
 
-span.preview-text {
-    font-size: 13px;
+span.file-language {
+    padding: 1px;
+    display: inline-block;
 }
+
+a.file-language {
+    color: dimgray
+}
+
+a.file-language:hover {
+    color: lightsalmon
+}
+
+i.item-toggle:hover {
+    cursor: pointer
+}
+
+
 
 /**/
 div.hidden {

--- a/dlx_rest/static/js/readonly_record.js
+++ b/dlx_rest/static/js/readonly_record.js
@@ -3,7 +3,7 @@ import { Jmarc } from "./jmarc.mjs"
 export let readonlyrecord = {
     props: ["api_prefix", "collection", "record_id"],
     template: `<div class="container">
-        <h5>{{record.getVirtualCollection()}}/{{record_id}}</h5>
+        <h5>{{virtualCollection}}/{{record_id}}</h5>
         <div v-for="field in record.fields" class="field" :data-tag="field.tag">
             <code class="text-primary">{{field.tag}}</code>
             <span v-if="!field.subfields">{{field.value}}</span>
@@ -14,7 +14,8 @@ export let readonlyrecord = {
     </div>`,
     data: function () {
         return {
-            record: {}
+            record: {},
+            virtualCollection: null
         }
     },
     created: function () {
@@ -24,6 +25,7 @@ export let readonlyrecord = {
 
         promise.then( jmarc => {
             this.record = jmarc
+            this.virtualCollection = jmarc.getVirtualCollection()
         })
     }
 }

--- a/dlx_rest/static/js/recordfiles.js
+++ b/dlx_rest/static/js/recordfiles.js
@@ -1,24 +1,17 @@
 export let recordfilecomponent = {
     props: ["api_prefix", "record_id"],
-    template: `<ul v-if="files" class="list-group list-group-horizontal list-group-flush m-0 p-0 pb-1">
-        <li v-for="file in files" class="list-group-item border-0 m-0 p-0 mr-1 float-left">
-            <ul class="list-group list-group-horizontal list-group-flush m-0 p-0 pb-1">
-                <li class="list-group-item list-group-item-dark border-0 m-0 p-0 px-1">
-                    {{file.language}} 
-                </li>
-                <li class="list-group-item list-group-item-dark border-0 m-0 p-0 px-1">
-                    <a :href="file.url + '?action=open'" target="_blank" title="open"><i class="fas fa-file text-dark"></i></a>
-                </li>                
-                <li class="list-group-item list-group-item-dark border-0 m-0 p-0 px-1">
-                    <a :href="file.url + '?action=download'" target="_blank" title="open"><i class="fas fa-cloud-download-alt text-dark"></i></a>
-                </li>
-                
-            </ul>
-        </li>
-    </ul>`,
+    template: /* html */ `
+    <div class="files-container">
+        <span v-for="file in files" :key="file.language" class="file-language">
+            <u><a :href="file.url + '?action=download'" target="_blank" :title="message" class="file-language">{{ langmap[file.language] }}</a></u>
+        </span>
+    </div>
+    `,
     data: function () {
         return {
-            files: null
+            message: "Download file or shift+click to open in a new browser tab",
+            langmap: {en: 'E', ar: 'A', zh: 'C', fr: 'F', ru: 'R', es: 'S'},
+            files: []
         }
     },
     created: async function() {

--- a/dlx_rest/static/js/search/itemadd.js
+++ b/dlx_rest/static/js/search/itemadd.js
@@ -8,8 +8,8 @@ export let itemaddcomponent = {
         <div @click="handleClick()">
             <i v-if="statusPending" class="fas fa-2x fa-spinner fa-pulse"></i>
             <i v-else-if="itemLocked" class="fas fa-2x fa-lock" data-toggle="tooltip" :title="'Item locked by ' + lockedBy" ></i>
-            <i v-else-if="inBasket" class="fas fa-2x fa-folder-minus" data-toggle="tooltip" :title="'Remove from basket'" ></i>
-            <i v-else class="fas fa-2x fa-folder-plus" data-toggle="tooltip" title="Add to basket"></i>
+            <i v-else-if="inBasket" class="fas fa-2x fa-folder-minus item-toggle" data-toggle="tooltip" :title="'Remove from basket'" ></i>
+            <i v-else class="fas fa-2x fa-folder-plus item-toggle" data-toggle="tooltip" title="Add to basket"></i>
         </div>
     `,
     data: function() {


### PR DESCRIPTION
* Trim and move file links inline with search result
* Rearrange column order (record preview)
* Use `readonlyrecord` component for the record preview
* Styling on mouse hover over search result rows, preview icons, and add item to basket icons

Related to #1329 