### PR TITLE
Import xml and csv

### DIFF
--- a/dlx_rest/static/js/import.js
+++ b/dlx_rest/static/js/import.js
@@ -142,6 +142,7 @@ export let importcomponent = {
             showErrors: false,
             detectedSpinner: false,
             selected: 0,
+            selectedRecords: false,     // this just (de)activates the submit button
             userShort: null,
             myProfile: {}
         }
@@ -226,9 +227,11 @@ export let importcomponent = {
             this.handleChange()
         },
         parseXml(file) {
-            console.log("Parsing XML")
+            //console.log("Parsing XML")
+            this.state = "preview"
             const reader = new FileReader()
             reader.readAsText(file)
+            this.detectedSpinner = true
             reader.onload = (res) => {
                 const parser = new DOMParser()
                 const doc = parser.parseFromString(res.target.result, 'text/xml')

--- a/dlx_rest/static/js/import.js
+++ b/dlx_rest/static/js/import.js
@@ -292,9 +292,11 @@ export let importcomponent = {
                 let csv = new CSV()
                 csv.parseText(res.target.result)
                 // listMarc fails
-                for (let jmarc of csv.listJmarc(this.collection)) {
-                    console.log(jmarc)
-                }
+                csv.listJmarc(this.collection).then( records => {
+                    for (let record of records) {
+                        this.records.push({ "jmarc": record, "mrk": "", "validationErrors": [], "fatalErrors": [], "checked": false })
+                    }
+                })
             }
         },
         parse(file) {

--- a/dlx_rest/static/js/import.js
+++ b/dlx_rest/static/js/import.js
@@ -1,5 +1,6 @@
 import { Jmarc } from './jmarc.mjs'
 import user from "./api/user.js"
+import { CSV } from './csv.mjs'
 
 export let importcomponent = {
     props: ["api_prefix"],
@@ -282,6 +283,19 @@ export let importcomponent = {
         },
         parseCsv(file) {
             
+            this.state = "preview"
+            const reader = new FileReader()
+            reader.readAsText(file)
+            const promises = []
+            this.detectedSpinner = true
+            reader.onload = (res) => {
+                let csv = new CSV()
+                csv.parseText(res.target.result)
+                // listMarc fails
+                for (let jmarc of csv.listJmarc(this.collection)) {
+                    console.log(jmarc)
+                }
+            }
         },
         parse(file) {
             /* 

--- a/dlx_rest/static/js/import.js
+++ b/dlx_rest/static/js/import.js
@@ -196,7 +196,15 @@ export let importcomponent = {
             // This replaces the list of files each time. It would be better to concatenate...
             this.fileList = [...this.$refs.import.files]
             if (this.importType == "records") {
-                this.parse(this.fileList[0])
+                let type = this.fileList[0].type
+                if (type == 'text/xml') {
+                    this.parseXml(this.fileList[0])
+                } else if (type == 'text/csv') {
+                    this.parseCsv(this.fileList[0])
+                } else {
+                    this.parse(this.fileList[0])
+                }
+                
             }
         },
         handleClick: function () {
@@ -216,6 +224,12 @@ export let importcomponent = {
             this.$refs.import.files = event.dataTransfer.files
             event.currentTarget.classList.remove("bg-dark")
             this.handleChange()
+        },
+        parseXml(file) {
+
+        },
+        parseCsv(file) {
+            
         },
         parse(file) {
             /* 

--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -751,6 +751,17 @@ export class Jmarc {
 		return true;
 	}
 
+	static async fromCsv(collection, csv) {
+		if (!["bibs", "auths"].includes(collection)) {
+			throw new Error("First argument must be \"bibs\" or \"auths\"")
+		}
+
+		let jmarc = new Jmarc(collection)
+		const promises = [];
+
+		
+	}
+
 	static async fromXml(collection, xml) {
 		if (!["bibs", "auths"].includes(collection)) {
 			throw new Error("First argument must be \"bibs\" or \"auths\"")

--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -777,13 +777,18 @@ export class Jmarc {
 				subfield.value = subfieldElement.textContent
 				if (subfield.code == "0") {
 					foundXref = subfield.value
+					subfield.xref = foundXref
+				}
+			})
+			for (let subfield of field.subfields) {
+				if (foundXref !== null) {
 					if (jmarc.isAuthorityControlled(field.tag, subfield.code)) {
 						subfield.xref = foundXref
 					} else {
 						promises.push(subfield.detectAndSetXref())
 					}
 				}
-			})
+			}
 		})
 		
 		await Promise.all(promises);

--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -751,6 +751,8 @@ export class Jmarc {
 		return true;
 	}
 
+	/* This function isn't used right now */
+	/*
 	static async fromCsv(collection, csv) {
 		if (!["bibs", "auths"].includes(collection)) {
 			throw new Error("First argument must be \"bibs\" or \"auths\"")
@@ -761,6 +763,7 @@ export class Jmarc {
 
 		
 	}
+	*/
 
 	static async fromXml(collection, xml) {
 		if (!["bibs", "auths"].includes(collection)) {


### PR DESCRIPTION
This adds XML and CSV parsing to the metadata import UI.

The CSV does basic parsing, but I'm missing something in terms of auth controlled subfields. Additionally, this doesn't properly set the 999. 