### PR TITLE
Parse CSV for import

### DIFF
--- a/dlx_rest/static/js/csv.mjs
+++ b/dlx_rest/static/js/csv.mjs
@@ -27,7 +27,7 @@ export class CSV {
         // header row. Multiple CSVs can be ingested in order to combine the
         // data.
 
-        const lines = text.split("\n");
+        const lines = text.split("\n").filter(x => x.trim() !== "");
         const header = parseCSVLine(lines.shift());
         header.forEach(x => this._header.add(x));
 

--- a/dlx_rest/static/js/import.js
+++ b/dlx_rest/static/js/import.js
@@ -265,7 +265,7 @@ export let importcomponent = {
                             let importSubfield = importField.createSubfield("a")
                             const today = new Date()
                             // user shortname
-                            importSubfield.value = `${this.userShort}i${today.getFullYear()}${today.getMonth() + 1}${today.getDate()}`
+                            importSubfield.value = `${this.userShort}i${today.getFullYear()}${String(today.getMonth() + 1).padStart(2, '0')}${String(today.getDate()).padStart(2, '0')}`
                             importField.new = true
 
                             this.records.push({ "jmarc": jmarc, "mrk": recordElement, "validationErrors": validationErrors, "fatalErrors": fatalErrors, "checked": false })
@@ -422,7 +422,7 @@ export let importcomponent = {
                             let importSubfield = importField.createSubfield("a")
                             const today = new Date()
                             // user shortname
-                            importSubfield.value = `${this.userShort}i${today.getFullYear()}${today.getMonth() + 1}${today.getDate()}`
+                            importSubfield.value = `${this.userShort}i${today.getFullYear()}${String(today.getMonth() + 1).padStart(2, '0')}${String(today.getDate()).padStart(2, '0')}`
                             importField.new = true
 
                             this.records.push({ "jmarc": jmarc, "mrk": mrk, "validationErrors": validationErrors, "fatalErrors": fatalErrors, "checked": false })

--- a/dlx_rest/static/js/import.js
+++ b/dlx_rest/static/js/import.js
@@ -123,6 +123,7 @@ export let importcomponent = {
                         </div>
                     </div>
                 </div>
+                <hr />
             </div>
             <button type="button" class="btn btn-secondary" @click="reinitApp">Start Over</button>
         </div>

--- a/dlx_rest/static/js/jmarc.mjs
+++ b/dlx_rest/static/js/jmarc.mjs
@@ -751,53 +751,6 @@ export class Jmarc {
 		return true;
 	}
 
-	static async fromCsv(collection, headers, values) {
-		if (!["bibs", "auths"].includes(collection)) {
-			throw new Error("First argument must be \"bibs\" or \"auths\"")
-		}
-
-		let jmarc = new Jmarc(collection)
-		const promises = [];
-
-        headers.forEach((header, index) => {
-			const [place, tag] = header.split(".")
-			if (tag == 'LDR') {
-				tag = '000'
-			}
-
-			let field = jmarc.createField(tag)
-			if (field instanceof ControlField) {
-				field.value = values[index]
-			} else {
-				let foundXref = null
-				let subfieldCode = header.split("$")[1]
-				field.createSubfield(subfieldCode).value = values[index]
-				if (subfieldCode == "0") {
-					foundXref = values[index]
-				}
-			}
-		})
-
-		for (let field of jmarc.fields) {
-			if (field instanceof DataField) {
-				for (let subfield of field.subfields) {
-					if (foundXref !== null) {
-						if (jmarc.isAuthorityControlled(field.tag, subfield.code)) {
-							subfield.xref = foundXref
-						} else {
-							promises.push(subfield.detectAndSetXref())
-						}
-					}
-				}
-			}
-		}
-
-		await Promise.all(promises)
-
-		return jmarc
-        
-    }
-
 	static async fromXml(collection, xml) {
 		if (!["bibs", "auths"].includes(collection)) {
 			throw new Error("First argument must be \"bibs\" or \"auths\"")


### PR DESCRIPTION
Continuation of fixes for #980 and #1426 

Fixes #1638 

This adds CSV as one of the import formats.

To test: 
1. Export a set of search results, keeping the result set fairly small. 
2. Choose CSV as the export format. 
3. (to import as new records) Edit the CSV in a text editor to remove the 001 header and field values. Save.
4. (to import as overwrites) Make no changes to the export file.
5. Navigate to Files -> Import Records
6. Drag and drop the exported CSV file.
7. Note any errors or other messages.
8. Choose records to import and click Submit Selected Records
9. Note that the records are imported or updated in place (you can verify with the 999 that is added).

Note that all of the import parsers are basically doing the same thing, but in slightly different ways. There is considerable repetition here that we should refactor once we have the basic functionality in place.