### PR TITLE
Display only E, F, S files on speech review

### DIFF
--- a/dlx_rest/static/js/recordfiles.js
+++ b/dlx_rest/static/js/recordfiles.js
@@ -1,9 +1,24 @@
 export let recordfilecomponent = {
-    props: ["api_prefix", "record_id"],
+    props: {
+        api_prefix: {
+            type: String,
+            required: true
+        },
+        record_id: {
+            type: String,
+            required: true
+        },
+        desired_languages: {
+            type: Array,
+            required: false,
+            default: () => ['ar', 'zh', 'en', 'fr', 'ru', 'es']
+        }
+    },
+    //props: ["api_prefix", "record_id", "desired_languages"],
     template: /* html */ `
     <div class="files-container">
         <span v-for="file in files" :key="file.language" class="file-language">
-            <u><a :href="file.url + '?action=download'" target="_blank" :title="message" class="file-language">{{ langmap[file.language] }}</a></u>
+            <u><a :href="file.url + '?action=open'" target="_blank" :title="message" class="file-language">{{ langmap[file.language] }}</a></u>
         </span>
     </div>
     `,
@@ -20,7 +35,13 @@ export let recordfilecomponent = {
             response => response.json()
         ).then(
             json => {
-                this.files = json.data
+                //this.files = json.data
+                for (let lang of this.desired_languages) {
+                    let file = json.data.find(f => f.language === lang);
+                    if (file) {
+                        this.files.push(file);
+                    }
+                }
             }
         )
     }

--- a/dlx_rest/static/js/speech_review.js
+++ b/dlx_rest/static/js/speech_review.js
@@ -88,7 +88,7 @@ export let speechreviewcomponent = {
                     <td>{{speech.speaker}}</td>
                     <td>{{speech.speaker_country}}</td>
                     <td>{{speech.country_org}}</td>
-                    <td><recordfilecomponent :api_prefix="api_prefix" :record_id="speech._id" /></td>
+                    <td><recordfilecomponent :api_prefix="api_prefix" :record_id="speech._id" :desired_languages="['en','fr','es']" /></td>
                     <td title="Toggle Agenda View">
                         <i class="fas fa-file" @click="toggleAgendas($event, speech._id, speech.agendas)"></i>
                     </td>


### PR DESCRIPTION
Fixes #1655 
Fixes #1656 

Adds an optional desired_languages prop on recordfiles.js so that any component that requires files can specify which languages are needed. The use of a default value preserves existing functionality.

Also changes the files link action from "download" to "open", so the file automatically opens in a new tab instead of downloading to the user's computer.