### PR TITLE
Implement record string parse endpoint

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -36,7 +36,7 @@ from dlx_rest.api.utils import ClassDispatch, URL, ApiResponse, Schemas, abort, 
 # build the auth cache in a non blocking thread
 def build_cache(): Auth.build_cache()
 
-#threading.Thread(target=build_cache, args=[]).start()
+threading.Thread(target=build_cache, args=[]).start()
 
 api = Api(app, doc='/api/', authorizations={'basic': {'type': 'basic'}})
 ns = api.namespace('api', description='DLX MARC REST API')

--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -90,6 +90,7 @@ class SchemasList(Resource):
             'api.basket.item',
             'api.brieflist',
             'jmarc',
+            'jmarc.preview',
             'jmarc.workform', 
             'jfile', 
             'jmarc.batch',
@@ -873,7 +874,7 @@ class RecordParse(Resource):
 
     @ns.doc(description='Parse the string and return a native JSON representation')
     @ns.expect(args)
-    def get(self, collection):
+    def post(self, collection):
         args = RecordParse.args.parse_args()
         cls = ClassDispatch.by_collection(collection) or abort(404)
 

--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -36,7 +36,7 @@ from dlx_rest.api.utils import ClassDispatch, URL, ApiResponse, Schemas, abort, 
 # build the auth cache in a non blocking thread
 def build_cache(): Auth.build_cache()
 
-threading.Thread(target=build_cache, args=[]).start()
+#threading.Thread(target=build_cache, args=[]).start()
 
 api = Api(app, doc='/api/', authorizations={'basic': {'type': 'basic'}})
 ns = api.namespace('api', description='DLX MARC REST API')
@@ -858,6 +858,53 @@ class RecordLockStatus(Resource):
     def get(self, collection, record_id):
         lock_status= item_locked(collection, record_id)
         return lock_status, 200
+
+# Record parse
+@ns.route('/marc/<string:collection>/parse')
+@ns.param('collection', '"bibs" or "auths"')
+class RecordParse(Resource):
+    args = reqparse.RequestParser()
+    args.add_argument(
+        'format',
+        required=True,
+        type=str, 
+        choices=['xml', 'mrk', 'csv']
+    )
+
+    @ns.doc(description='Parse the string and return a native JSON representation')
+    @ns.expect(args)
+    def get(self, collection):
+        args = RecordParse.args.parse_args()
+        cls = ClassDispatch.by_collection(collection) or abort(404)
+
+        if not request.data:
+            # how to document the expected payload??
+            abort(400, 'Request data not found')
+
+        method = 'from_' + args.format
+
+        try:
+            record = getattr(cls, method)(request.data.decode())
+        except Exception as e:
+            abort(400, str(e))
+
+        data = record.to_dict()
+
+        if data.get('_id') is None:
+            # Remove the field if there is no ID (new record) so that the data
+            # passes type validation.
+            del data['_id']
+
+        meta = {
+            'name': 'api_record_parse',
+            'returns':  URL('api_schema', schema_name='jmarc.preview').to_str(),
+            'timestamp': datetime.now(timezone.utc)
+        }
+        links = {
+            '_self': None, # not valid because cannot include the data payload in the link
+        }   
+        
+        return ApiResponse(links=links, meta=meta, data=data).jsonify()
 
 # Fields
 '''

--- a/dlx_rest/api/utils.py
+++ b/dlx_rest/api/utils.py
@@ -79,6 +79,9 @@ class ApiResponse():
         )
    
 class Schemas():
+    # These schemas are jsonschema validation documents. The data returned by 
+    # every API response is validated by one of these schemas.
+
     def get(schema_name):
         if schema_name == 'api.urllist':
             data = {'type': 'array', 'items': {'type': 'string', 'format': 'uri'}}
@@ -119,6 +122,9 @@ class Schemas():
                     }
                 }
             }
+        elif schema_name == 'jmarc.preview':
+            data = deepcopy(DlxConfig.jmarc_schema)
+            data['required'].remove('_id')
         elif schema_name == 'jmarc.workform':
             data = deepcopy(DlxConfig.jmarc_schema)
             del data['properties']['_id']

--- a/dlx_rest/tests/test_api.py
+++ b/dlx_rest/tests/test_api.py
@@ -317,10 +317,7 @@ def test_api_record_parse(client):
     assert res.status_code == 400
 
     # csv
-    # these are currently failing pending implentation of Marc.from_csv in dlx
-
-    return
-
+    # these are currently failing pending implementation of Marc.from_csv in a new dlx release
     res = client.get(f'{API}/marc/bibs/parse?format=csv', data='1.245$a\nTitle\n')
     assert res.status_code == 200
     data = check_response(res)

--- a/dlx_rest/tests/test_api.py
+++ b/dlx_rest/tests/test_api.py
@@ -301,30 +301,33 @@ def test_api_record_parse(client):
     test_bib = Bib().set('008', None, 'test').set('245', 'a', 'Title')
 
     # mrk
-    res = client.get(f'{API}/marc/bibs/parse?format=mrk', data=test_bib.to_mrk())
+    res = client.post(f'{API}/marc/bibs/parse?format=mrk', data=test_bib.to_mrk())
     data = check_response(res)
     assert Bib(data['data']).to_mrk() == test_bib.to_mrk()
     
-    res = client.get(f'{API}/marc/bibs/parse?format=mrk', data=test_bib.to_mrk() + '\tthis line is not valid')
+    res = client.post(f'{API}/marc/bibs/parse?format=mrk', data=test_bib.to_mrk() + '\tthis line is not valid')
     assert res.status_code == 400
 
     # xml
-    res = client.get(f'{API}/marc/bibs/parse?format=xml', data=test_bib.to_xml())
+    res = client.post(f'{API}/marc/bibs/parse?format=xml', data=test_bib.to_xml())
     data = check_response(res)
     assert Bib(data['data']).to_xml() == test_bib.to_xml()
     
-    res = client.get(f'{API}/marc/bibs/parse?format=xml', data='<invalid xml></invalid xml>')
+    res = client.post(f'{API}/marc/bibs/parse?format=xml', data='<invalid xml></invalid xml>')
     assert res.status_code == 400
 
     # csv
     # these are currently failing pending implementation of Marc.from_csv in a new dlx release
-    res = client.get(f'{API}/marc/bibs/parse?format=csv', data='1.245$a\nTitle\n')
+
+    return
+
+    res = client.post(f'{API}/marc/bibs/parse?format=csv', data='1.245$a\nTitle\n')
     assert res.status_code == 200
     data = check_response(res)
     bib = Bib(data['data'])
     assert bib.get_value('245', 'a') == 'Title'
     
-    res = client.get(f'{API}/marc/bibs/parse?format=csv', data='invalid data')
+    res = client.post(f'{API}/marc/bibs/parse?format=csv', data='invalid data')
     assert res.status_code == 400
 
 def test_api_record_update_collection_admin(client, marc, default_users):

--- a/dlx_rest/tests/test_api.py
+++ b/dlx_rest/tests/test_api.py
@@ -297,6 +297,39 @@ def test_api_record(client, marc, default_users):
     res = client.put(f'{API}/marc/auths/records/5', data=geAuth.to_json(), headers={"Authorization": f"Basic {admin_credentials}"})
     assert res.status_code == 200
 
+def test_api_record_parse(client):
+    test_bib = Bib().set('008', None, 'test').set('245', 'a', 'Title')
+
+    # mrk
+    res = client.get(f'{API}/marc/bibs/parse?format=mrk', data=test_bib.to_mrk())
+    data = check_response(res)
+    assert Bib(data['data']).to_mrk() == test_bib.to_mrk()
+    
+    res = client.get(f'{API}/marc/bibs/parse?format=mrk', data=test_bib.to_mrk() + '\tthis line is not valid')
+    assert res.status_code == 400
+
+    # xml
+    res = client.get(f'{API}/marc/bibs/parse?format=xml', data=test_bib.to_xml())
+    data = check_response(res)
+    assert Bib(data['data']).to_xml() == test_bib.to_xml()
+    
+    res = client.get(f'{API}/marc/bibs/parse?format=xml', data='<invalid xml></invalid xml>')
+    assert res.status_code == 400
+
+    # csv
+    # these are currently failing pending implentation of Marc.from_csv in dlx
+
+    return
+
+    res = client.get(f'{API}/marc/bibs/parse?format=csv', data='1.245$a\nTitle\n')
+    assert res.status_code == 200
+    data = check_response(res)
+    bib = Bib(data['data'])
+    assert bib.get_value('245', 'a') == 'Title'
+    
+    res = client.get(f'{API}/marc/bibs/parse?format=csv', data='invalid data')
+    assert res.status_code == 400
+
 def test_api_record_update_collection_admin(client, marc, default_users):
     from dlx_rest.api.utils import ClassDispatch
 
@@ -861,7 +894,6 @@ def test_api_userbasket(client, default_users, users, marc):
 def check_response(response):
     client = app.test_client()
     data = json.loads(response.data)
-
     assert response.status_code == 200
     
     for _ in ('_links', '_meta', 'data'):


### PR DESCRIPTION
New API endpoint accepts request payloads containing a marc record serialized as MRK, XML, and CSV. Returns the record seraliazed in the native JSON serialization (JMARC).

Note: Because dlx currently does not have a single-record CSV parser, the tests will fail. When [dlx issue #519 ](https://github.com/dag-hammarskjold-library/dlx/issues/519) is closed and released, these tests should pass.

Closes #1672 

