### PR TITLE
Add number of bibs attached to authority record to authority field in record editor

### DIFF
--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -3222,10 +3222,24 @@ export let multiplemarcrecordcomponent = {
         setAuthControl(field, subfield) {
             let component = this;
             subfield.valueSpan.classList.add("authority-controlled");
+            
    
             if (! "xref" in subfield) {
                 subfield.valueSpan.classList.add("authority-controlled-unmatched")
             }
+
+            // Create wrapper div for count component
+            let countWrapper = document.createElement('div');
+            subfield.valueSpan.parentElement.appendChild(countWrapper);
+
+            // Mount count component using Vue.extend
+            const CountComponent = Vue.extend(countcomponent);
+            new CountComponent({
+                propsData: {
+                    api_prefix: this.prefix,
+                    recordId: subfield.xref
+                }
+            }).$mount(countWrapper);
  
             if (subfield.xrefCell.children.length === 0) {
                 if (subfield.xref) {

--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -3228,6 +3228,17 @@ export let multiplemarcrecordcomponent = {
                 subfield.valueSpan.classList.add("authority-controlled-unmatched")
             }
 
+            // Find and remove any existing count components
+            let existingCountComponent = subfield.valueSpan.parentElement.querySelector(".count-component");
+            if (existingCountComponent) {
+                // Get the Vue instance associated with the component and destroy it
+                const vueInstance = existingCountComponent.__vue__;
+                if (vueInstance) {
+                    vueInstance.$destroy();
+                }
+                existingCountComponent.remove();
+            }
+
             // Create wrapper div for count component
             let countWrapper = document.createElement('div');
             subfield.valueSpan.parentElement.appendChild(countWrapper);

--- a/dlx_rest/static/js/search/count.js
+++ b/dlx_rest/static/js/search/count.js
@@ -3,7 +3,7 @@
 export let countcomponent = {
     props: ["api_prefix", "recordId"],
     template: `
-        <span class="mx-2">
+        <span class="mx-2 count-component">
             <a class="result-link" :href="uiBase + 'records/bibs/search?q=xref:' + recordId + '&subtype=all'" :title="search_count === '⌕' ? 'Use count pending' : ''">({{search_count}})</a>
         </span>
     `,


### PR DESCRIPTION
Fixes #1340

Adds the authority use count as an extra div in any authority controlled field in the editor interface. Shouldn't impact the auth lookup text entry.