### PR TITLE
Add call number (099 $c) to results list display

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -286,7 +286,7 @@ class RecordsList(Resource):
             abort(404, 'Maximum limit is 1000')
         
         if fmt == 'brief':
-            tags = ['191', '245', '269', '520', '596', '700', '710', '711', '791', '989', '991', '992'] if collection == 'bibs' \
+            tags = ['099', '191', '245', '269', '520', '596', '700', '710', '711', '791', '989', '991', '992'] if collection == 'bibs' \
                 else ['100', '110', '111', '130', '150', '151', '190', '191', '400', '410', '411', '430', '450', '451', '490', '491', '591']
             
             # make sure logical fields are available for sorting

--- a/dlx_rest/api/utils.py
+++ b/dlx_rest/api/utils.py
@@ -231,6 +231,8 @@ def brief_bib(record):
     # Should be truncated in display with hover showing the rest
     f520 = [record.get_value('520', 'a')]
 
+    f099c = record.get_values('099', 'c')
+
     return {
         '_id': record.id,
         'url': URL('api_record', collection='bibs', record_id=record.id).to_str(),
@@ -240,7 +242,8 @@ def brief_bib(record):
         'types': '; '.join(ctypes),
         'agendas': agendas,
         'f596': f596,
-        'f520': f520
+        'f520': f520,
+        'f099c': f099c
     }
 
 def brief_speech(record):

--- a/dlx_rest/static/js/search/search.js
+++ b/dlx_rest/static/js/search/search.js
@@ -441,7 +441,7 @@ export let searchcomponent = {
 
                         let rtype = result["types"].split("::")
 
-                        myResult["second_line"] = [result['f099c'], result["symbol"], result["date"], rtype[rtype.length - 1]].filter(Boolean).join(" | ")
+                        myResult["second_line"] = [result["f099c"].length > 0 ? result["f099c"].join(', ') : false, result["symbol"], result["date"], rtype[rtype.length - 1]].filter(Boolean).join(" | ")
                         myResult["f520"] = result["f520"]
 
                         if (this.vcoll == "089:'B22'") {

--- a/dlx_rest/static/js/search/search.js
+++ b/dlx_rest/static/js/search/search.js
@@ -441,8 +441,9 @@ export let searchcomponent = {
 
                         let rtype = result["types"].split("::")
 
-                        myResult["second_line"] = [result["symbol"], result["date"], rtype[rtype.length - 1]].filter(Boolean).join(" | ")
+                        myResult["second_line"] = [result['f099c'], result["symbol"], result["date"], rtype[rtype.length - 1]].filter(Boolean).join(" | ")
                         myResult["f520"] = result["f520"]
+
                         if (this.vcoll == "089:'B22'") {
                             myResult["agendas"] = result["agendas"]
                             myResult["f596"] = result["f596"]


### PR DESCRIPTION
Fixes #975

NB: We can move the field around if necessary. It's currently located in the same place UNDL has it, on the second line. 