### PR TITLE
1721-error-styling

### DIFF
--- a/dlx_rest/static/js/import.js
+++ b/dlx_rest/static/js/import.js
@@ -185,6 +185,9 @@ export let importcomponent = {
     methods: {
         reinitApp: function () {
             this.records = []
+            this.selectedRecords = false
+            this.recordsWithWarnings = 0
+            this.fatalErrors = []
             this.showErrors = false
             this.state = 'init'
             this.collection = "bibs"


### PR DESCRIPTION
Adds alert-danger styling to the fatal errors display

Fixes #1719

Also slightly rewords the record counts.

And fixes the select/import process, which was broken.