### PR TITLE
remove unused props

### DIFF
--- a/dlx_rest/static/js/components/search-history.js
+++ b/dlx_rest/static/js/components/search-history.js
@@ -1,21 +1,11 @@
 export let searchHistoryComponent = {
     name: 'SearchHistory',
     props: {
-
-        searchButtonId: {
-            type: String,
-            required: true
-        },
-
         searchInputId: {
             type: String,
             required: true
         },
 
-        userEmail: {
-            type: String,
-            required: true
-        },
         apiPrefix: {
             type: String,
             required: true


### PR DESCRIPTION
There were two extraneous props in the search history component that were not in use, so they could be removed.