### PR TITLE
Prevent browser from auto-scrolling on entering auth lookup dropdown

### DIFF
--- a/dlx_rest/static/js/record.js
+++ b/dlx_rest/static/js/record.js
@@ -3635,7 +3635,7 @@ function keyupAuthLookup(event) {
                         if (event.keyCode === 40) {
                             // down arrow key
                             dropdown.list = list;
-                            list.focus(); // list now navigable by default <select> behavior
+                            list.focus({ preventScroll: true }); // list now navigable by default <select> behavior
                             list.firstChild.selected = true; // jump to to first choice
                         }
                     });


### PR DESCRIPTION
Closes #942

This explicitly sets the option to prevent the browser from scrolling down when the authorities lookup dropdown is focused. It was only affecting Chrome.