### PR TITLE
Add batch delete to speech and auth reviews; cleanup error messages; cleanup console logging

### DIFF
--- a/dlx_rest/static/js/api/user.js
+++ b/dlx_rest/static/js/api/user.js
@@ -11,7 +11,7 @@ export default {
     },
 
     hasPermission(user, action) {
-        console.log("checking", user, action)
+        //console.log("checking", user, action)
         if (user.data.permissions.includes(action)) {
             return true;
         }

--- a/dlx_rest/static/js/auth_review.js
+++ b/dlx_rest/static/js/auth_review.js
@@ -64,6 +64,11 @@ export let authreviewcomponent = {
                                 @click.prevent="sendToBasket">
                             Send {{selectedRecords.length}} to Basket
                         </button>
+                        <button class="btn btn-danger btn-sm ml-2"
+                                @click.prevent="confirmDelete"
+                                v-if="canDelete">
+                            Delete {{selectedRecords.length}} Records
+                        </button>
                     </div>
                     <div v-if="isSearching || submitted">
                         {{resultCount}} results found{{isSearching ? ' so far' : ''}} 
@@ -194,6 +199,7 @@ export let authreviewcomponent = {
             showSpinner: false,
             searchDate: urlDate || defaultDate,
             myBasket: {},
+            myProfile: null,
             selectedRecords: [],
             uibase: myUIBase,
             searchTime: 0,
@@ -208,7 +214,17 @@ export let authreviewcomponent = {
             searchError: null,
         }
     },
-    created: function () {
+    computed: {
+        canDelete() {
+            if (!user.hasPermission(this.myProfile, 'batchDelete')) {
+                return false
+            }
+            return this.selectedRecords.length > 0 && 
+                !this.selectedRecords.some(r => r.locked) 
+        },
+    },
+    created: async function () {
+        this.myProfile = await user.getProfile(this.api_prefix, 'my_profile')
         this.updateSearchQuery();
         this.submitSearch();
         this.refreshBasket();
@@ -392,6 +408,61 @@ export let authreviewcomponent = {
         cancelSearch() {
             this.showSpinner = false;
             this.isSearching = false;
+        },
+        async executeDelete() {
+            if (!user.hasPermission(this.myProfile, 'batchDelete')) return;
+            this.isDeleting = true;
+            const successfulDeletes = new Set();
+            const failedDeletes = new Set();
+
+            try {
+                // Process all deletes
+                for (const record of this.selectedRecords) {
+                    try {
+                        const response = await fetch(
+                            `${this.api_prefix}marc/${record.collection}/records/${record.record_id}`, 
+                            {
+                                method: 'DELETE',
+                                headers: {
+                                    'Content-Type': 'application/json'
+                                }
+                            }
+                        );
+
+                        if (response.ok) {
+                            successfulDeletes.add(record.record_id);
+                        } else {
+                            failedDeletes.add(record.record_id);
+                        }
+                    } catch (error) {
+                        console.error(`Error deleting record ${record.record_id}:`, error);
+                        failedDeletes.add(record.record_id);
+                    }
+                }
+
+                // Remove successfully deleted records from the display
+                this.records = this.records.filter(record => {
+                    // Check if this record's ID is in the successfulDeletes set
+                    return !successfulDeletes.has(record._id.toString());
+                });
+
+                // Update result count
+                this.resultCount = this.records.length;
+
+                // Show results message
+                if (failedDeletes.size > 0) {
+                    alert(`Successfully deleted ${successfulDeletes.size} records.\nFailed to delete ${failedDeletes.size} records.`);
+                } else {
+                    alert(`Successfully deleted ${successfulDeletes.size} records.`);
+                }
+
+                // Clear selection
+                this.selectNone();
+                
+            } finally {
+                this.isDeleting = false;
+                $('#deleteConfirmModal').modal('hide');
+            }
         }
     },
     components: {

--- a/dlx_rest/static/js/search.js
+++ b/dlx_rest/static/js/search.js
@@ -474,7 +474,7 @@ export let searchcomponent = {
     created: async function () {
         // Get the user profile for permissions checking
         this.myProfile = await user.getProfile(this.api_prefix, 'my_profile')
-        console.log(this.myProfile)
+        //console.log(this.myProfile)
 
         const urlParams = new URLSearchParams(window.location.search);
         const searchQuery = urlParams.get("q");


### PR DESCRIPTION
Further to #1665 applies the batch delete to the remaining search interfaces.