### PR TITLE
Set some options for auto-deployments

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -1,82 +1,56 @@
 name: Build and push nightly image
+
 on:
   schedule:
-    - cron: '0 0 * * *'  # Runs every day at midnight UTC
+    - cron: '0 0 * * *'  # Every day at midnight UTC
   workflow_dispatch:
 
 jobs:
-    build:
-        name: Build and push Docker image
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v3
-              with:
-                fetch-depth: 0  # Fetch all history for all branches and tags
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-            - name: Install test dependencies
-              run: |
-                python -m pip install --upgrade pip
-                pip install pytest
-                pip install -r requirements.txt
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
-            - name: Run tests
-              run: |
-                pytest --maxfail=1 --disable-warnings -q
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
 
-            - name: Configure AWS Credentials
-              if: success()  # Only continue if tests pass
-              uses: aws-actions/configure-aws-credentials@v4
-              with:
-                aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                aws-region: us-east-1
+      - name: Build Docker image
+        run: |
+          docker build -t ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:nightly .
 
-            - name: Login to ECR
-              id: login-ecr
-              uses: aws-actions/amazon-ecr-login@v2
+      - name: Run tests
+        run: |
+          docker run --rm ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:nightly pytest
 
-            - name: Build Docker image
-              id: build-image
-              env:
-                ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-                ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-              run: |
-                docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:nightly .
+      - name: Push Docker image
+        run: |
+          docker push ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:nightly
 
-            - name: Tag Docker image
-              env:
-                ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-                ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-              run: |
-                docker tag $ECR_REGISTRY/$ECR_REPOSITORY:nightly $ECR_REGISTRY/$ECR_REPOSITORY:nightly
+      - name: Prepare ECS task definition
+        run: |
+          sed "s|<account_id>|${{ secrets.AWS_ACCOUNT_ID }}|g" ecs/ecs-task-definition.json.template > ecs/ecs-task-definition.json
 
-            - name: Push Docker image
-              env:
-                ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-                ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-              run: |
-                docker push $ECR_REGISTRY/$ECR_REPOSITORY:nightly
+      - name: Fill in image id in ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: ./ecs/ecs-task-definition.json
+          container-name: dlx-rest-nightly
+          image: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:nightly
 
-            - name: Substitute AWS Account ID in task definition
-              run: |
-                sed "s|<account_id>|${{ secrets.AWS_ACCOUNT_ID }}|g" ecs/ecs-task-definition.json.template > ecs/ecs-task-definition.json
-
-            - name: Fill in image id in ECS task definition
-              id: task-def
-              uses: aws-actions/amazon-ecs-render-task-definition@v1
-              env:
-                ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-                ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-              with:
-                task-definition: ./ecs/ecs-task-definition.json
-                container-name: dlx-rest-nightly
-                image: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:nightly
-
-            - name: Deploy to ECS
-              uses: aws-actions/amazon-ecs-deploy-task-definition@v2
-              with:
-                cluster: dlx-rest-nightly-cluster
-                service: dlx-rest-nightly-service
-                task-definition: ${{ steps.task-def.outputs.task-definition }}
-                wait-for-service-stability: true
+      - name: Deploy to ECS
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          cluster: dlx-rest-nightly-cluster
+          service: dlx-rest-nightly-service
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          wait-for-service-stability: true

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -51,6 +51,6 @@ jobs:
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
           cluster: dlx-rest-nightly-cluster
-          service: dlx-rest-nightly-service
+          service: dlx-rest-task-service-4dkyfv2k
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           wait-for-service-stability: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ ENV DLX_REST_DEV=True
 
 EXPOSE 5000
 
-CMD ["gunicorn", "-b", "0.0.0.0:5000", "dlx_rest.app:app", "--workers", "4", "--timeout", "120"]
+CMD ["gunicorn", "-b", "0.0.0.0:5000", "dlx_rest.app:dev_app", "--workers", "4", "--timeout", "120"]

--- a/dlx_rest/app.py
+++ b/dlx_rest/app.py
@@ -78,8 +78,6 @@ uat_app = DispatcherMiddleware(Flask('dummy_root'), {
     '/uat-editor': app,
 })
 
-app.config['PREFERRED_URL_SCHEME'] = 'https'
-
 # Main app routes
 from dlx_rest.routes import *
 

--- a/dlx_rest/app.py
+++ b/dlx_rest/app.py
@@ -2,6 +2,7 @@ from flask import Flask, Response, url_for, jsonify, abort as flask_abort, sessi
 #from flask_restx import Resource, Api, reqparse
 from flask_login import LoginManager
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
+from werkzeug.middleware.proxy_fix import ProxyFix
 from mongoengine import connect, disconnect
 from mongomock import MongoClient as MockClient
 from flask_cors import CORS
@@ -16,6 +17,7 @@ mimetypes.add_type('application/javascript', '.mjs')
 
 app = Flask(__name__)
 app.config.from_object(Config)
+app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
 CORS(app)
 login_manager = LoginManager()
 login_manager.init_app(app)

--- a/dlx_rest/app.py
+++ b/dlx_rest/app.py
@@ -78,6 +78,9 @@ uat_app = DispatcherMiddleware(Flask('dummy_root'), {
     '/uat-editor': app,
 })
 
+dev_app.config['PREFERRED_URL_SCHEME'] = 'https'
+uat_app.config['PREFERRED_URL_SCHEME'] = 'https'
+
 # Main app routes
 from dlx_rest.routes import *
 

--- a/dlx_rest/app.py
+++ b/dlx_rest/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, Response, url_for, jsonify, abort as flask_abort, session, send_from_directory
 #from flask_restx import Resource, Api, reqparse
 from flask_login import LoginManager
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
 from mongoengine import connect, disconnect
 from mongomock import MongoClient as MockClient
 from flask_cors import CORS
@@ -68,6 +69,14 @@ try:
     app.secret_key=Config.secret_key
 except AttributeError:
     app.secret_key='top secret!'
+
+# Dummy root routes for dev and uat environments
+dev_app = DispatcherMiddleware(Flask('dummy_root'), {
+    '/dev-editor': app,
+})
+uat_app = DispatcherMiddleware(Flask('dummy_root'), {
+    '/uat-editor': app,
+})
 
 # Main app routes
 from dlx_rest.routes import *

--- a/dlx_rest/app.py
+++ b/dlx_rest/app.py
@@ -78,8 +78,7 @@ uat_app = DispatcherMiddleware(Flask('dummy_root'), {
     '/uat-editor': app,
 })
 
-dev_app.config['PREFERRED_URL_SCHEME'] = 'https'
-uat_app.config['PREFERRED_URL_SCHEME'] = 'https'
+app.config['PREFERRED_URL_SCHEME'] = 'https'
 
 # Main app routes
 from dlx_rest.routes import *

--- a/dlx_rest/config.py
+++ b/dlx_rest/config.py
@@ -9,6 +9,8 @@ class Config(object):
     VERSION = "v2.11"     # Set this in each new milestone/release.
 
     bucket = 'undl-files'
+
+    PREFERRED_URL_SCHEME = 'http'
     
     if 'DLX_REST_TESTING' in os.environ:
         environment = 'test'
@@ -26,6 +28,7 @@ class Config(object):
         sync_log_collection = 'sync_log'
         bucket = 'dev-undl-files'
     elif 'DLX_REST_DEV' in os.environ:
+        PREFERRED_URL_SCHEME = 'https'
         environment = 'dev'
         client = boto3.client('ssm')
         secret_key = client.get_parameter(Name='metadata_cache_key')['Parameter']['Value']
@@ -51,6 +54,7 @@ class Config(object):
         sync_log_collection = 'sync_log'
         bucket = 'dev-undl-files'
     elif 'DLX_REST_UAT' in os.environ:
+        PREFERRED_URL_SCHEME = 'https'
         environment = 'uat'
         client = boto3.client('ssm')
         secret_key = client.get_parameter(Name='metadata_cache_key')['Parameter']['Value']
@@ -65,6 +69,7 @@ class Config(object):
         sync_log_collection = 'sync_log'
         bucket = 'dev-undl-files'
     elif 'DLX_REST_PRODUCTION' in os.environ:
+        PREFERRED_URL_SCHEME = 'https'
         environment = 'prod'
         client = boto3.client('ssm')
         secret_key = client.get_parameter(Name='metadata_cache_key')['Parameter']['Value']

--- a/dlx_rest/routes.py
+++ b/dlx_rest/routes.py
@@ -795,7 +795,7 @@ def update_file():
 @requires_permission('importMarc')
 def import_marc():
     this_prefix = url_for('doc', _external=True)
-    print(this_prefix)
+    #print(this_prefix)
     return render_template('import_marc.html', api_prefix=this_prefix)
 
 @app.route('/reports/dashboard02', methods=["GET"])


### PR DESCRIPTION
This PR builds on the Dockerfile, ecs/ecs-task-definition.json.template, and .github/workflows/build-nightly.yml to:

1. Build, test, and push a Docker image to AWS ECR every night, built from the current main branch.
2. Update an already provisioned ECS service that has:
  a. An Application Load Balancer
  b. End-to-end encryption using our existing SSL certificates
  c. "dummy roots" to allow us to serve the app differentially on different root paths, e.g., /dev-editor

If build succeeds each night, we have an up-to-date application deployed automatically and served at https://metadata.un.org/dev-editor

We can extend this to create additional automatic deployments as necessary, including for production if we like.