### PR TITLE
Add 667 to auth search results

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -342,7 +342,7 @@ class RecordsList(Resource):
 
         if fmt == 'brief':
             tags = ['099', '191', '245', '269', '520', '596', '700', '710', '711', '791', '989', '991', '992'] if collection == 'bibs' \
-                else ['100', '110', '111', '130', '150', '151', '190', '191', '400', '410', '411', '430', '450', '451', '490', '491', '591']
+                else ['100', '110', '111', '130', '150', '151', '190', '191', '400', '410', '411', '430', '450', '451', '490', '491', '591', '667']
             
             # make sure logical fields are available for sorting
             tags += (list(DlxConfig.bib_logical_fields.keys()) + list(DlxConfig.auth_logical_fields.keys()))

--- a/dlx_rest/api/utils.py
+++ b/dlx_rest/api/utils.py
@@ -276,8 +276,9 @@ def brief_auth(record):
     if record.heading_field.tag == '191':
         f491 = '; '.join(record.get_values('491','a','b','c','d'))
         f591 = '; '.join(record.get_values('591','a','b','c','d'))
+        f667 = '; '.join(record.get_values('667','a','b','c','d'))
         heading_alt_ary = []
-        for f in [f491, f591]:
+        for f in [f491, f591, f667]:
             if len(f) > 0:
                 heading_alt_ary.append(f)
         alt_field = '; '.join(heading_alt_ary)


### PR DESCRIPTION
Closes #916

Ensures that 667 is also included in auth search results; we already had 491 and 591.