### PR TITLE
allow 'all' subtype in get logical fields; fix error using 'all' subtype in search

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -176,7 +176,7 @@ class CollectionLogicalFields(Resource):
     args.add_argument(
         'subtype',
         type=str,
-        choices=['','default','speech','vote'],
+        choices=['','all','default','speech','vote'],
         help='Record collection subtype',
         default='default'
     )

--- a/dlx_rest/static/js/components/search.js
+++ b/dlx_rest/static/js/components/search.js
@@ -808,7 +808,7 @@ export let searchcomponent = {
             let next = `${this.api_prefix}marc/${this.collection}/records?search=${this.searchTerm}&format=brief&sort=${this.currentSort}&direction=${this.currentDirection}`;
             
             if (this.subtype && this.subtype !== 'default') {
-                if (this.subtype === 'speech' || this.subtype === 'vote') {
+                if (this.subtype === 'speech' || this.subtype === 'vote' || this.subtype === 'all') {
                     next = `${this.api_prefix}marc/${this.collection}/records?search=${this.searchTerm}&subtype=${this.subtype}&format=brief&sort=${this.currentSort}&direction=${this.currentDirection}`;
                 } else {
                     next = `${this.api_prefix}marc/${this.collection}/records?search=${this.searchTerm}&subtype=${this.subtype}&format=brief_${this.subtype}&sort=${this.currentSort}&direction=${this.currentDirection}`;


### PR DESCRIPTION
Closes #1792