### PR TITLE
Replicate existing search type (double quotes)

### DIFF
--- a/dlx_rest/static/js/components/search.js
+++ b/dlx_rest/static/js/components/search.js
@@ -744,7 +744,7 @@ export let searchcomponent = {
                 /^[A-Za-z]+\/.+/.test(terms[0])
             ) {
                 // Looks like a symbol, rewrite as symbol:"TERM"
-                return `symbol:'${terms[0].toUpperCase()}'`;
+                return `symbol:"${terms[0]}"`;
             }
             return q;
         },


### PR DESCRIPTION
The current behavior of the automatic symbol search is to use double quotes (phrase match). Single quotes are exact match