### PR TITLE
Revert sort param back to "created" from "_id"

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -237,7 +237,7 @@ class RecordsList(Resource):
     args.add_argument(
         'sort',
         type=str,
-        choices=['relevance', 'updated', 'created', '_id', 'date', 'symbol', 'title', 'subject', 'heading', 'country_org', 'speaker', 'body', 'agenda'],
+        choices=['relevance', 'updated', 'created', 'date', 'symbol', 'title', 'subject', 'heading', 'country_org', 'speaker', 'body', 'agenda'],
     )
     args.add_argument(
         'direction', type=str, 
@@ -391,6 +391,7 @@ class RecordsList(Resource):
             recordset = cls.from_aggregation(pipeline, collation=collation)
         else:
             sort = [(sort_by, -1)] if (args['direction'] or '').lower() == 'desc' else [(sort_by, 1)]
+            sort_by = 'created' if sort_by == '_id' else sort_by # reverts param back to "created" when constructing the "_next" url
             
             try:
                 recordset = cls.from_query(


### PR DESCRIPTION
Keeps the query param as "created" when sorting