### PR TITLE
Use valkey server if it exists

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,6 @@ pyparsing==3.2.5
 python-ulid==3.1.0
 sentry-sdk==2.38.0
 troposphere==4.9.4
-valkey==6.6.1
+valkey==6.1.1
 WTForms==3.2.1
 zipp==3.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,6 @@ pyparsing==3.2.5
 python-ulid==3.1.0
 sentry-sdk==2.38.0
 troposphere==4.9.4
+valkey==6.6.1
 WTForms==3.2.1
 zipp==3.23.0


### PR DESCRIPTION
Checks if there is a Valkey server running on localhost, and if so set the dlx.DB.cache attribute to it. Note: this will have no effect, even if a server is running, until #1915 is closed.