### PR TITLE
Handle basket read/write/delete in record data

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -912,6 +912,7 @@ class Record(Resource):
         data['updated'] = record.updated
         data['user'] = record.user
         data['files'] = files_data
+        data['basket'] = record.basket
 
         meta = {
             'name': 'api_record',
@@ -2209,6 +2210,13 @@ class MyBasketRecord(Resource):
         else:
             # The item is not locked, so we can add it to our basket
             this_u.my_basket().add_item(item)
+            
+            # Add the basket owner to the rcord data
+            getattr(DB, item['collection']).update_one(
+                {'_id': int(item['record_id'])},
+                {'$set': {'basket': current_user.username}}
+            )
+
             return {},201      
 
 @ns.route('/userprofile/my_profile/basket/addBulk')
@@ -2236,9 +2244,17 @@ class MyBasketClear(Resource):
             this_u = User.objects.get(id=current_user['id'])
             user_id = this_u['id']
             this_basket = Basket.objects(owner=this_u)[0]
+
+            for item in this_basket['items']:
+                getattr(DB, item['collection']).update_one(
+                    {'_id': int(item['record_id'])},
+                    {'$set': {'basket': None}}
+                )
+
             this_basket.clear()
-        except:
-            raise
+
+        except Exception as e:
+            raise e
 
         return 200
 
@@ -2286,11 +2302,21 @@ class MyBasketItem(Resource):
         try:
             this_u = User.objects.get(id=current_user['id'])
             this_basket = Basket.objects(owner=this_u)[0]
+            
+            # Update basket owner in record data
+            if item := next(filter(lambda x: x['id'] == item_id, this_basket.items), None):
+                getattr(DB, item['collection']).update_one(
+                    {'_id': int(item['record_id'])},
+                    {'$set': {'basket': None}}
+                )
+
             this_basket.remove_item(item_id)
+
+            
         except IndexError:
             abort(400)
-        except:
-            raise
+        except Exception as e:
+            raise e
 
         return 200
 

--- a/dlx_rest/api/utils.py
+++ b/dlx_rest/api/utils.py
@@ -247,7 +247,8 @@ def brief_bib(record):
         'agendas': agendas,
         'f596': f596,
         'f520': f520,
-        'f099c': f099c
+        'f099c': f099c,
+        'basket': record.basket
     }
 
 def brief_speech(record):
@@ -265,7 +266,7 @@ def brief_speech(record):
         # This item_locked function is running for each record returned in this API call
         #'locked': item_locked("bibs", record.id)["locked"],
         'locked': False,
-        #'myBasket': False
+        'basket': record.basket
     }
 
 def brief_auth(record):
@@ -288,7 +289,8 @@ def brief_auth(record):
         'url': URL('api_record', collection='auths', record_id=record.id).to_str(),
         'heading': '; '.join(map(lambda x: x.value, record.heading_field.subfields)),
         'alt': alt_field,
-        'heading_tag': record.heading_field.tag
+        'heading_tag': record.heading_field.tag,
+        'basket': record.basket
     }
 
 def item_locked(collection, record_id):

--- a/dlx_rest/static/js/components/itemadd.js
+++ b/dlx_rest/static/js/components/itemadd.js
@@ -3,7 +3,7 @@
 import basket from "../api/basket.js";
 
 export let itemaddcomponent = {
-    props: ["api_prefix", "collection", "recordId", "myBasket"],
+    props: ["api_prefix", "collection", "brief", "myBasket"],
     template: `
         <div @click="handleClick()">
             <i v-if="statusPending" class="fas fa-spinner fa-pulse"></i>
@@ -35,17 +35,17 @@ export let itemaddcomponent = {
         async initBasket() {
 
             this.myBasket.forEach(item => {
-                if (item.collection === this.collection && item.record_id === this.recordId) {
+                if (item.collection === this.collection && parseInt(item.record_id) === this.brief._id) {
                     this.inBasket = true;
                     this.itemLocked = false;
                 }
             });
 
             if (! this.inBasket) {
-                let lockedStatus = await basket.itemLocked(this.api_prefix, this.collection, this.recordId);
-                
-                if (lockedStatus["locked"] == true) {
-                    this.lockedBy = lockedStatus["by"];
+                const owner = this.brief.basket
+
+                if (owner) {
+                    this.lockedBy = owner
                     this.itemLocked = true;
                 } else {
                     this.inBasket = false;
@@ -63,10 +63,10 @@ export let itemaddcomponent = {
             this.statusPending = true;
             
             if (this.inBasket) {
-                await basket.deleteItem(this.myBasket, this.collection, this.recordId);
+                await basket.deleteItem(this.myBasket, this.collection, this.brief._id);
                 this.inBasket = false;
             } else {
-                await basket.createItem(this.api_prefix, 'userprofile/my_profile/basket', this.collection, this.recordId);
+                await basket.createItem(this.api_prefix, 'userprofile/my_profile/basket', this.collection, this.brief._id);
                 this.inBasket = true;
             }
 

--- a/dlx_rest/static/js/components/search.js
+++ b/dlx_rest/static/js/components/search.js
@@ -261,9 +261,9 @@ export let searchcomponent = {
                             <td>
                                 <itemadd
                                     :api_prefix="api_prefix"
-                                    :collection="collection"
-                                    :recordId="record._id"
                                     :myBasket="myBasket"
+                                    :collection="collection"
+                                    :brief="record"
                                     @mousedown.native.stop
                                     @mouseup.native.stop
                                     @click.native.stop


### PR DESCRIPTION
This sets/deletes the basket owner in the record data, so that the basket owner can be returned with the record data. This allows us to avoid looking up each basket status individually in the search results. Closes #1917 