### PR TITLE
Alert user of reason for failed delete; remove record from results

### DIFF
--- a/dlx_rest/static/js/components/search.js
+++ b/dlx_rest/static/js/components/search.js
@@ -1333,13 +1333,9 @@ export let searchcomponent = {
                         console.error(`Error deleting record ${record.record_id}:`, error);
                         failedDeletes.add(record.record_id);
                     }
-                }
 
-                // Remove successfully deleted records from the display
-                this.records = this.records.filter(record => {
-                    // Check if this record's ID is in the successfulDeletes set
-                    return !successfulDeletes.has(record._id.toString());
-                });
+                    this.records = this.records.filter(x => x._id !== record.record_id)
+                }
 
                 // Update result count
                 this.resultCount = this.records.length;


### PR DESCRIPTION
This alerts the user with a pop up window for each failed delete, but we may want to aggregate the failures and alert the user of all of them at once. 

Also fixes the removal of the record from the reactive records property, which updates the results display.