### PR TITLE
Fix cached search result order

### DIFF
--- a/dlx_rest/api/__init__.py
+++ b/dlx_rest/api/__init__.py
@@ -452,6 +452,10 @@ class RecordsList(Resource):
             # a request is made to this route with the the serach_id as a param. 
             # Note: It's possible this should be handled in dlx since it is interacting directly with the DB.
 
+            # As above, need to add unique field to sort by for order consistency
+            if sort_by != '_id':
+                sort_object.append(('_id', 1))
+
             def savecache():
                 from pymongo import UpdateOne
 
@@ -498,9 +502,7 @@ class RecordsList(Resource):
 
         recordset =  cls.from_query(
             {'_id': {'$in': [x['_id'] for x in ([] if total == 0 else data.get('data'))]}},
-            projection=project,
-            sort=sort_object,
-            collation=collation
+            projection=project
         )
         
         if x := subfield_projection:

--- a/dlx_rest/static/js/components/search.js
+++ b/dlx_rest/static/js/components/search.js
@@ -1086,6 +1086,7 @@ export let searchcomponent = {
                 
                 // Apply head filters if needed
                 newRecords = this.applyActiveHeadFilters(newRecords);
+                
                 newRecords.forEach(record => {
                     if (!this.records.some(r => r._id === record._id)) {
                         this.records.push(record);


### PR DESCRIPTION
The search that populates the results cache needed a unique value to sort by in order to create consistent ordering for when the primary sort field is not unique.

Closes #1967 