### PR TITLE
Build cache only if doesn't already exist

### DIFF
--- a/dlx_rest/static/js/components/itemadd.js
+++ b/dlx_rest/static/js/components/itemadd.js
@@ -33,7 +33,6 @@ export let itemaddcomponent = {
     },
     methods: {
         async initBasket() {
-
             this.myBasket.forEach(item => {
                 if (item.collection === this.collection && parseInt(item.record_id) === this.brief._id) {
                     this.inBasket = true;


### PR DESCRIPTION
This is mostly just so that the cache doesn't have to be rebuilt if running the app in a localhost environment, where the connection may be slow.