### PR TITLE
Restore the checkboxes on regular auths search

### DIFF
--- a/dlx_rest/static/js/components/search.js
+++ b/dlx_rest/static/js/components/search.js
@@ -249,7 +249,7 @@ export let searchcomponent = {
                             @mousemove="handleMouseMove($event, record, index)" 
                             @mouseup="handleMouseUp($event)">
                             <td>{{index + 1}}</td>
-                            <td v-if="collection !== 'auths'">
+                            <td>
                                 <input type="checkbox" 
                                     :checked="record.selected"
                                     :disabled="record.locked || record.myBasket"


### PR DESCRIPTION
Closes #2010 

Restores checkboxes on the auths search so users can individually de-select from a group selection.