### PR TITLE
Standardize dlx install to point to PyPI package dlx-odm to allow better management

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aniso8601==10.0.1
 blinker==1.9.0
 cachelib==0.14.0
 cfn-flip==1.3.0
-dlx @ git+https://github.com/dag-hammarskjold-library/dlx@v1.5.7
+dlx-odm==1.6.0
 email-validator==2.3.0
 Flask==3.1.3
 Flask-Cors==6.0.5


### PR DESCRIPTION
The dlx library is now represented on the Python Package Index (PyPI) as dlx-odm and is installable via `pip install dlx-odm`. This will allow us to use standard package naming in requirements.txt and leverage Dependabot to help keep things up to date.

This is not a substantive change.